### PR TITLE
ksys/snd: Add SoundResource

### DIFF
--- a/src/KingSystem/Sound/CMakeLists.txt
+++ b/src/KingSystem/Sound/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(uking PRIVATE
   sndInfoData.cpp
   sndInfoData.h
+  sndResource.cpp
   sndResource.h
 )

--- a/src/KingSystem/Sound/sndResource.cpp
+++ b/src/KingSystem/Sound/sndResource.cpp
@@ -1,0 +1,26 @@
+#include "KingSystem/Sound/sndResource.h"
+#include <heap/seadDisposer.h>
+#include <heap/seadExpHeap.h>
+#include <heap/seadFrameHeap.h>
+
+namespace ksys::snd {
+
+SEAD_SINGLETON_DISPOSER_IMPL(SoundResource)
+
+SoundResource::~SoundResource() {
+    mSoundResourceHeap->destroy();
+    _30->destroy();
+    if (mSoundDebugHeap)
+        mSoundDebugHeap->destroy();
+}
+
+void SoundResource::init(sead::Heap* heap, sead::Heap* debug_heap, bool extra_large) {
+    mSoundResourceHeap =
+        sead::FrameHeap::create(extra_large ? 0x9583000 : 0x6383000, "SoundResource", heap, 0x1000,
+                                sead::FrameHeap::cHeapDirection_Forward, false);
+    if (debug_heap)
+        mSoundDebugHeap = sead::ExpHeap::create(0x1E00000u, "SoundDebug", debug_heap, 0x1000,
+                                                sead::ExpHeap::cHeapDirection_Forward, false);
+}
+
+}  // namespace ksys::snd

--- a/src/KingSystem/Sound/sndResource.h
+++ b/src/KingSystem/Sound/sndResource.h
@@ -5,19 +5,19 @@
 
 namespace ksys::snd {
 
-// FIXME: incomplete
 class SoundResource {
     SEAD_SINGLETON_DISPOSER(SoundResource)
     SoundResource() = default;
     virtual ~SoundResource();
 
 public:
+    void init(sead::Heap* heap, sead::Heap* debug_heap, bool extra_large);
     sead::Heap* getSoundDebugHeap() const { return mSoundDebugHeap; }
 
 private:
-    sead::Heap* mSoundResourceHeap;
-    void* _30;
-    sead::Heap* mSoundDebugHeap;
+    sead::Heap* mSoundResourceHeap = nullptr;
+    sead::Heap* _30 = nullptr;  // TODO find out what this does
+    sead::Heap* mSoundDebugHeap = nullptr;
 };
 KSYS_CHECK_SIZE_NX150(SoundResource, 0x40);
 


### PR DESCRIPTION
All functions match. `deleteInstance` is going unused. `_30`'s purpose is still unknown and therefor marked with `TODO`.