### PR TITLE
ksys/snd: Add MusicDefinition

### DIFF
--- a/src/KingSystem/Sound/CMakeLists.txt
+++ b/src/KingSystem/Sound/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(uking PRIVATE
   sndInfoData.cpp
   sndInfoData.h
+  sndMusicDefinition.cpp
+  sndMusicDefinition.h
   sndResource.cpp
   sndResource.h
 )

--- a/src/KingSystem/Sound/sndMusicDefinition.cpp
+++ b/src/KingSystem/Sound/sndMusicDefinition.cpp
@@ -1,0 +1,96 @@
+#include "KingSystem/Sound/sndMusicDefinition.h"
+
+namespace ksys::snd {
+
+// NON_MATCHING: two bigger diffs cause a different regalloc
+// 1. During `SafeString` generation of line
+// `auto categoryDefines_list = agl::utl::getResParameterList(root_list, "CategoryDefines");`
+// 2. Mis-ordered operations around
+// `addList(&mCategoryList, "CategoryDefines");`
+void MusicDefinition::doCreate_(u8* data, u32 file_size, sead::Heap* heap) {
+    auto archive = agl::utl::ResParameterArchive(data);
+    auto root_list = archive.getRootList();
+
+    auto musicDefines_list = agl::utl::getResParameterList(root_list, "MusicDefines");
+    if (musicDefines_list) {
+        s32 musicDefines_list_length = musicDefines_list.getResParameterObjNum();
+        if (musicDefines_list_length == 0) {
+            return;
+        }
+        mMusicBuffer.allocBufferAssert(musicDefines_list_length, heap);
+
+        for (auto it = mMusicBuffer.begin(), end = mMusicBuffer.end(); it != end; ++it) {
+            auto param_obj = &it->param_obj;
+            it->name.init("", "Name", param_obj);
+            it->category.init("", "Category", param_obj);
+            it->volume.init(1, "Volume", param_obj);
+            it->is_enable_weather_filter.init(false, "IsEnableWeatherFilter", param_obj);
+            it->is_indoor_ducking.init(false, "IsIndoorDucking", param_obj);
+
+            mMusicList.addObj(param_obj,
+                              sead::FormatFixedSafeString<32>("MusicDefine_%d", it.getIndex()));
+        }
+
+        addList(&mMusicList, "MusicDefines");
+    }
+
+    auto categoryDefines_list = agl::utl::getResParameterList(root_list, "CategoryDefines");
+    if (categoryDefines_list) {
+        s32 categoryDefines_list_length = categoryDefines_list.getResParameterObjNum();
+        if (categoryDefines_list_length == 0)
+            return;
+        mCategoryBuffer.allocBufferAssert(categoryDefines_list_length, heap);
+
+        for (auto it = mCategoryBuffer.begin(), end = mCategoryBuffer.end(); it != end; ++it) {
+            it->name.init("", "Name", &it->param_obj);
+            it->priority_value.init(0, "PriorityValue", &it->param_obj);
+
+            mCategoryList.addObj(&it->param_obj, sead::FormatFixedSafeString<32>(
+                                                     "CategoryDefine_%d", it.getIndex()));
+        }
+
+        addList(&mCategoryList, "CategoryDefines");
+    }
+
+    if (data)
+        applyResParameterArchive(agl::utl::ResParameterArchive(data));
+
+    for (auto& music : mMusicBuffer) {
+        if (music.category.ref() == str_EventBgm) {
+            music.is_event_bgm = true;
+            mEventBgmCount++;
+        } else {
+            music.is_event_bgm = false;
+        }
+    }
+}
+
+int MusicDefinition::getMusicIndexByName(const sead::SafeString& name) {
+    for (int i = 0; i < mMusicBuffer.size(); i++) {
+        if (mMusicBuffer.get(i)->name.ref() == name) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+const sead::SafeString& MusicDefinition::getMusicCategoryByName(const sead::SafeString& name) {
+    for (int i = 0; i < mMusicBuffer.size(); i++) {
+        if (mMusicBuffer.get(i)->name.ref() == name) {
+            return mMusicBuffer.get(i)->category.ref();
+        }
+    }
+    return sead::SafeString::cEmptyString;
+}
+
+int MusicDefinition::getPriorityValueByCategoryName(const sead::SafeString& name) {
+    for (int i = 0; i < mCategoryBuffer.size(); i++) {
+        auto element = mCategoryBuffer.get(i);
+        if (element->name.ref() == name) {
+            return element->priority_value.ref();
+        }
+    }
+    return 0;
+}
+
+}  // namespace ksys::snd

--- a/src/KingSystem/Sound/sndMusicDefinition.h
+++ b/src/KingSystem/Sound/sndMusicDefinition.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <agl/Utils/aglParameter.h>
+#include <agl/Utils/aglParameterIO.h>
+#include <agl/Utils/aglParameterList.h>
+#include <agl/Utils/aglParameterObj.h>
+#include <container/seadBuffer.h>
+#include <resource/seadResource.h>
+#include "KingSystem/Utils/Types.h"
+
+namespace ksys::snd {
+
+static sead::SafeString str_EventBgm = "EventBgm";
+
+class MusicDefinition : public sead::DirectResource, public agl::utl::IParameterIO {
+    SEAD_RTTI_OVERRIDE(MusicDefinition, sead::DirectResource)
+
+    struct MusicDefine {
+        agl::utl::Parameter<sead::SafeString> name;
+        agl::utl::Parameter<sead::SafeString> category;
+        agl::utl::Parameter<float> volume;
+        agl::utl::Parameter<bool> is_enable_weather_filter;
+        agl::utl::Parameter<bool> is_indoor_ducking;
+        bool is_event_bgm;
+        agl::utl::ParameterObj param_obj;
+    };
+    struct CategoryDefine {
+        agl::utl::Parameter<sead::SafeString> name;
+        agl::utl::Parameter<u32> priority_value;
+        agl::utl::ParameterObj param_obj;
+    };
+
+public:
+    void doCreate_(u8* data, u32 file_size, sead::Heap* heap) override;
+    int getMusicIndexByName(const sead::SafeString& name);
+    const sead::SafeString& getMusicCategoryByName(const sead::SafeString& name);
+    int getPriorityValueByCategoryName(const sead::SafeString& name);
+
+private:
+    sead::Buffer<MusicDefine> mMusicBuffer;
+    agl::utl::ParameterList mMusicList;
+    int mEventBgmCount;
+    sead::Buffer<CategoryDefine> mCategoryBuffer;
+    agl::utl::ParameterList mCategoryList;
+};
+KSYS_CHECK_SIZE_NX150(MusicDefinition, 0x2A8);
+
+}  // namespace ksys::snd


### PR DESCRIPTION
Most functions match, except for the main and biggest one: `doCreate` still has at least two major diffs.

```
// NON_MATCHING: two bigger diffs cause a different regalloc
// 1. During `SafeString` generation of line
// `auto categoryDefines_list = agl::utl::getResParameterList(root_list, "CategoryDefines");`
// 2. Mis-ordered operations around
// `addList(&mCategoryList, "CategoryDefines");`
```