### PR TITLE
ksys/act: Add LinkTag

### DIFF
--- a/src/KingSystem/ActorSystem/CMakeLists.txt
+++ b/src/KingSystem/ActorSystem/CMakeLists.txt
@@ -99,6 +99,8 @@ target_sources(uking PRIVATE
   actInstParamPack.cpp
   actInstParamPack.h
   actLifeRecoveryInfo.h
+  actLinkTag.cpp
+  actLinkTag.h
   actPlayerInfo.cpp
   actPlayerInfo.h
   actTag.h

--- a/src/KingSystem/ActorSystem/actLinkTag.cpp
+++ b/src/KingSystem/ActorSystem/actLinkTag.cpp
@@ -1,0 +1,13 @@
+#include "KingSystem/ActorSystem/actLinkTag.h"
+
+namespace ksys::act {
+
+LinkTag* LinkTag::construct(const BaseProc::CreateArg& arg, sead::Heap* heap){
+    return new (heap, std::nothrow) LinkTag(arg);
+}
+
+LinkTag::LinkTag(const BaseProc::CreateArg& arg) : BaseProc(arg), mJob(this,&LinkTag::calc) {
+    mJobHandlers[3] = &mJob;
+}
+
+}  // namespace ksys::act

--- a/src/KingSystem/ActorSystem/actLinkTag.h
+++ b/src/KingSystem/ActorSystem/actLinkTag.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "KingSystem/ActorSystem/actBaseProc.h"
+#include "KingSystem/ActorSystem/actBaseProcJobHandler.h"
+#include "KingSystem/Map/mapMubinIter.h"
+#include "KingSystem/Utils/Types.h"
+
+namespace ksys::map {
+class Object;
+}  // namespace ksys::map
+
+namespace ksys::act {
+
+class LinkTag : public BaseProc {
+public:
+    enum Type : u8 { And, Or, NAnd, NOr, XOr, Count, Pulse, None };
+
+    SEAD_RTTI_OVERRIDE(LinkTag, BaseProc)
+
+    static LinkTag* construct(const BaseProc::CreateArg& arg, sead::Heap* heap);
+
+    LinkTag(const BaseProc::CreateArg& arg);
+    void calc();
+
+    BaseProcJobHandlerT<LinkTag> mJob;
+    unsigned int triggeredLinkFlags[3] = {0,0,0};
+    LinkTag::Type linkTagType = And;
+    char field_1DD = 0xFF;
+    char field_1DE = 0;
+    char field_1DF = 0xFF;
+    unsigned short flags = 0;
+    char tagCount = 0;
+    char field_1E3 = 0;
+    u32 counter = 0;
+    int field_1E8 = 0;
+    unsigned int mCalcFrameFlags = 0;
+    int hashId = 0;
+    int field_1F4 = 0;
+    map::MubinIter mMubinIter;
+    map::Object* mMapObj = nullptr;
+};
+KSYS_CHECK_SIZE_NX150(LinkTag, 0x210);
+
+}  // namespace ksys::act


### PR DESCRIPTION
Base research point: `LinkTag::construct` method with an inlined `ctor` at `0x7100D3778C`. All functions are already labeled in the CSV before this PR, so they should already be named correctly in the database even without these names and implementations.