### PR TITLE
gsys: Add ParticleConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ target_link_libraries(uking PUBLIC agl)
 add_subdirectory(lib/aal)
 target_link_libraries(uking PRIVATE aal)
 
+add_subdirectory(lib/gsys)
+target_link_libraries(uking PRIVATE gsys)
+
 add_subdirectory(lib/EventFlow)
 target_link_libraries(uking PRIVATE evfl)
 

--- a/lib/gsys/.clang-format
+++ b/lib/gsys/.clang-format
@@ -1,0 +1,74 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     100
+CommentPragmas:  '^ (IWYU pragma:|NOLINT)'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   []
+IncludeCategories:
+  - Regex:           '^<[Ww]indows\.h>$'
+    Priority:        1
+  - Regex:           '^<'
+    Priority:        2
+  - Regex:           '^"'
+    Priority:        3
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++17
+TabWidth:        4
+UseTab:          Never
+...

--- a/lib/gsys/CMakeLists.txt
+++ b/lib/gsys/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(gsys CXX ASM)
+
+add_library(gsys OBJECT
+  include/gsys/gsysORUtil.h
+  include/gsys/gsysParticleConfig.h
+  src/gsys/gsysParticleConfig.cpp
+)
+
+target_compile_options(gsys PRIVATE -fno-exceptions)
+target_compile_options(gsys PRIVATE -fno-strict-aliasing)
+target_compile_options(gsys PRIVATE -Wno-invalid-offsetof)
+target_include_directories(gsys PUBLIC include/)
+
+if(NOT TARGET sead)
+  add_subdirectory(../sead)
+endif()
+target_link_libraries(gsys PUBLIC sead)
+
+if(NOT TARGET agl)
+  add_subdirectory(../agl)
+endif()
+target_link_libraries(gsys PUBLIC agl)

--- a/lib/gsys/include/gsys/gsysORUtil.h
+++ b/lib/gsys/include/gsys/gsysORUtil.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace sead {
+class Heap;
+
+namespace hostio {
+class Node;
+}
+}  // namespace sead
+
+namespace gsys::ORUtil {
+
+enum class Icon {
+    _b = 0xB,
+};
+
+void setNodeMetaIcon(sead::hostio::Node* node, Icon icon, sead::Heap* heap);
+
+}  // namespace gsys::ORUtil

--- a/lib/gsys/include/gsys/gsysParticleConfig.h
+++ b/lib/gsys/include/gsys/gsysParticleConfig.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <agl/Utils/aglParameter.h>
+#include <agl/Utils/aglParameterIO.h>
+#include <agl/Utils/aglParameterObj.h>
+#include <hostio/seadHostIONode.h>
+
+namespace gsys {
+
+class ParticleConfig : public sead::hostio::Node, public agl::utl::IParameterIO {
+public:
+    ParticleConfig();
+    const char* getLightMapName(unsigned int index) const;
+    void initialize(sead::Heap* heap, sead::Heap* hio_heap);
+    void applyResouce(const void* data);
+
+private:
+    [[maybe_unused]] agl::utl::IParameterObj _1d8;      // unused
+    [[maybe_unused]] short _208 = 0;                    // unused
+    [[maybe_unused]] sead::FixedSafeString<0x40> _210;  // unused
+    agl::utl::ParameterObj mData2;
+    agl::utl::Parameter<u32> mGpuParticleHeapSize;
+    agl::utl::Parameter<u32> mEffectModelHeapSize;
+    agl::utl::Parameter<u32> mPtclEmitCallbackHeapSize;
+    agl::utl::Parameter<bool> mEnableParticleLinearDepth;
+    agl::utl::Parameter<bool> mEnableBatchProcessStreamOut;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName0;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName1;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName2;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName3;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName4;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName5;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName6;
+    agl::utl::Parameter<sead::FixedSafeString<0x40>> mLightMapName7;
+};
+
+}  // namespace gsys

--- a/lib/gsys/src/gsys/gsysParticleConfig.cpp
+++ b/lib/gsys/src/gsys/gsysParticleConfig.cpp
@@ -1,0 +1,67 @@
+#include "gsys/gsysParticleConfig.h"
+
+#include "gsys/gsysORUtil.h"
+
+namespace gsys {
+
+ParticleConfig::ParticleConfig()
+    : IParameterIO("ptclconf", 0),
+      mGpuParticleHeapSize(0x100000, "gpu_particle_heap_size", "GpuParticleHeapSize", &mData2),
+      mEffectModelHeapSize(0x20000, "EffectModelHeapSize", "effect_model_heap_size", &mData2),
+      mPtclEmitCallbackHeapSize(0x10000, "ptcl_emit_callback_heap_size", "PtclEmitCallbackHeapSize",
+                                &mData2),
+      mEnableParticleLinearDepth(true, "enable_particle_lineardepth", "EnableParticleLinearDepth",
+                                 &mData2),
+      mEnableBatchProcessStreamOut(true, "enable_batck_process_streamout",
+                                   "EnableBatchProcessStreamOut", &mData2),  // typo: batck
+      mLightMapName0(sead::FixedSafeString<0x40>("Default"), "light_map_name_0", "ライトマップ0",
+                     &mData2),
+      mLightMapName1(sead::FixedSafeString<0x40>("Default"), "light_map_name_1", "ライトマップ1",
+                     &mData2),
+      mLightMapName2(sead::FixedSafeString<0x40>("Default"), "light_map_name_2", "ライトマップ2",
+                     &mData2),
+      mLightMapName3(sead::FixedSafeString<0x40>("Default"), "light_map_name_3", "ライトマップ3",
+                     &mData2),
+      mLightMapName4(sead::FixedSafeString<0x40>("Default"), "light_map_name_4", "ライトマップ4",
+                     &mData2),
+      mLightMapName5(sead::FixedSafeString<0x40>("Default"), "light_map_name_5", "ライトマップ5",
+                     &mData2),
+      mLightMapName6(sead::FixedSafeString<0x40>("Default"), "light_map_name_6", "ライトマップ6",
+                     &mData2),
+      mLightMapName7(sead::FixedSafeString<0x40>("Default"), "light_map_name_7", "ライトマップ7",
+                     &mData2) {
+    addObj(&mData2, "ParticleConfig");
+}
+
+const char* ParticleConfig::getLightMapName(unsigned int index) const {
+    switch (index) {
+    case 0:
+        return mLightMapName0->cstr();
+    case 1:
+        return mLightMapName1->cstr();
+    case 2:
+        return mLightMapName2->cstr();
+    case 3:
+        return mLightMapName3->cstr();
+    case 4:
+        return mLightMapName4->cstr();
+    case 5:
+        return mLightMapName5->cstr();
+    case 6:
+        return mLightMapName6->cstr();
+    case 7:
+        return mLightMapName7->cstr();
+    default:
+        return "";
+    }
+}
+
+void ParticleConfig::initialize(sead::Heap* heap, sead::Heap* hio_heap) {
+    ORUtil::setNodeMetaIcon(this, ORUtil::Icon::_b, hio_heap);
+}
+
+void ParticleConfig::applyResouce(const void* data) {
+    applyResParameterArchive(agl::utl::ResParameterArchive{data});
+}
+
+}  // namespace gsys


### PR DESCRIPTION
Most functions match, except one: `ParticleConfig::getLightMapName` mismatches, as Clang decides to optimize the code better this time than in the original code... Other than that, everything matches and compiles just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/63)
<!-- Reviewable:end -->
