### PR TITLE
Add PlacementMap, stubs: PlacementMapMgr and PlacementMapMgrMapArray

### DIFF
--- a/src/KingSystem/Map/CMakeLists.txt
+++ b/src/KingSystem/Map/CMakeLists.txt
@@ -22,4 +22,6 @@ target_sources(uking PRIVATE
   mapRail.h
   mapStagePreActorCache.cpp
   mapStagePreActorCache.h
+  mapPlacementMap.cpp
+  mapPlacementMap.h
 )

--- a/src/KingSystem/Map/CMakeLists.txt
+++ b/src/KingSystem/Map/CMakeLists.txt
@@ -14,6 +14,10 @@ target_sources(uking PRIVATE
   mapObjectLink.h
   mapPlacementActors.cpp
   mapPlacementActors.h
+  mapPlacementMap.cpp
+  mapPlacementMap.h
+  mapPlacementMapMgr.cpp
+  mapPlacementMapMgr.h
   mapPlacementMgr.cpp
   mapPlacementMgr.h
   mapPlacementTree.cpp
@@ -22,6 +26,4 @@ target_sources(uking PRIVATE
   mapRail.h
   mapStagePreActorCache.cpp
   mapStagePreActorCache.h
-  mapPlacementMap.cpp
-  mapPlacementMap.h
 )

--- a/src/KingSystem/Map/mapPlacementMap.cpp
+++ b/src/KingSystem/Map/mapPlacementMap.cpp
@@ -5,7 +5,7 @@ namespace ksys::map {
 PlacementMap::PlacementMap() {
     mInitStatus = InitStatus::None;
     mParsedNumStaticObjs = 0xFFFFFFFF;
-    mStaticMapLoaded = StaticMap_None;
+    mStaticMapLoaded = StaticMap::None;
     mNumStaticObjs = 0xFFFFFFFF;
     mMat = sead::Matrix34f::ident;
     mDistanceToCurrentMapUnit = 0;

--- a/src/KingSystem/Map/mapPlacementMap.cpp
+++ b/src/KingSystem/Map/mapPlacementMap.cpp
@@ -1,0 +1,15 @@
+#include "KingSystem/Map/mapPlacementMap.h"
+
+namespace ksys::map {
+
+SEAD_SINGLETON_DISPOSER_IMPL(PlacementMapMgr)
+
+void PlacementMapMgr::junk() {
+    /*  Here to force the compiler to include PlacementMap */
+    PlacementMap x;
+    auto y = new PlacementMap;
+    (void)(x);
+    (void)(y);
+}
+
+}  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMap.cpp
+++ b/src/KingSystem/Map/mapPlacementMap.cpp
@@ -2,14 +2,35 @@
 
 namespace ksys::map {
 
-SEAD_SINGLETON_DISPOSER_IMPL(PlacementMapMgr)
+PlacementMap::PlacementMap() {
+    mInitStatus = InitStatus::None;
+    mParsedNumStaticObjs = 0xFFFFFFFF;
+    mStaticMapLoaded = StaticMap_None;
+    mNumStaticObjs = 0xFFFFFFFF;
+    mMat = sead::Matrix34f::ident;
+    mDistanceToCurrentMapUnit = 0;
+    mSkipLoadStaticMap = 0;
+    _38c = 0xFFFFFFFF;
+    mIdx = 0;
+    _388 = 0;
+    mCol = 0;
+    mRow = 0;
+    mNumRoutes = 0;
+    mP18 = 0;
+    mMgr = 0;
+    mPa = 0;
+    mDynamicGroupIdx = 0xFFFFFFFF;
+    mRes[0].mStatus = HkscRes::Status::_0;
+    mRes[1].mStatus = HkscRes::Status::_0;
+    mRes[2].mStatus = HkscRes::Status::_0;
+    mRes[3].mStatus = HkscRes::Status::_0;
+}
 
-void PlacementMapMgr::junk() {
-    /*  Here to force the compiler to include PlacementMap */
-    PlacementMap x;
-    auto y = new PlacementMap;
-    (void)(x);
-    (void)(y);
+PlacementMap::~PlacementMap() {
+    mRoutes.freeBuffer();
+    for (auto& r : mRes) {
+        r.cleanup();
+    }
 }
 
 }  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -1,0 +1,204 @@
+#pragma once
+
+#include <container/seadBuffer.h>
+#include <container/seadPtrArray.h>
+#include <heap/seadDisposer.h>
+#include <heap/seadExpHeap.h>
+#include <math/seadMatrix.h>
+#include "KingSystem/Map/mapPlacementActors.h"
+#include "KingSystem/Physics/StaticCompound/physStaticCompound.h"
+#include "KingSystem/Resource/resHandle.h"
+
+namespace ksys::map {
+
+class PlacementMapMgr; /* See Below */
+class MapProperties;
+class Placement18;
+class FarActorMerge;
+
+class PlacementMapHkscRes {
+    enum {
+        Status_2 = 2,  // Call cleanupHkscMaybe(), if ok, set to 3
+        Status_3 = 3,
+        Status_4 = 4,  // Call staticCompoundStuff, if ok, set to 5
+        Status_5 = 5,
+    };
+
+public:
+    PlacementMapHkscRes() = default;
+    ~PlacementMapHkscRes() = default;
+
+    ksys::res::Handle res;
+    s32 statusMaybe;
+    bool _54;
+    bool _55;
+    bool _56;
+    bool _57;
+
+    void cleanup() {
+        auto r = res.getResource();
+        if (auto ptr = sead::DynamicCast<ksys::phys::StaticCompound>(r)) {
+            if (ptr->calledFromMapDtor()) {
+                ptr->cleanUp();
+            }
+        }
+    }
+};
+KSYS_CHECK_SIZE_NX150(PlacementMapHkscRes, 0x58);
+
+class PlacementMap {
+    enum { StaticMap_None = 0, StaticMap_Loaded = 1 << 0, StaticMap_Parsed = 1 << 8 };
+
+public:
+    __attribute__((noinline)) PlacementMap() {
+        initStatus = PlacementMap::InitStatus_None;
+        parsedNumStaticObjs = 0xFFFFFFFF;
+        staticMapLoaded = StaticMap_None;
+        numStaticObjs = 0xFFFFFFFF;
+        mat = sead::Matrix34f::ident;
+        distanceToCurrentMapUnit = 0;
+        skipLoadStaticMap = 0;
+        _38c = 0xFFFFFFFF;
+        idx = 0;
+        _388 = 0;
+        col = 0;
+        row = 0;
+        numRoutes = 0;
+        p18 = 0;
+        mgr = 0;
+        pa = 0;
+        dynamicGroupIdx = 0xFFFFFFFF;
+        res[0].statusMaybe = 0;
+        res[1].statusMaybe = 0;
+        res[2].statusMaybe = 0;
+        res[3].statusMaybe = 0;
+    };
+
+    ~PlacementMap() {
+        routes.freeBuffer();
+        for (auto& r : res) {
+            r.cleanup();
+        }
+    }
+
+    s32 loadStaticMap_(u8 load);
+    void doLoadStaticMap_(bool load);
+
+    bool parseStaticMap_(sead::ExpHeap* heap, u8* data);
+    void parseMap_(sead::ExpHeap* heap, u8* data, int group, u32 idx);
+
+    bool loadDynamicMap();
+
+    s32 parseDynamicMap();
+
+    void resetDynamic();
+    void unload();
+    void unloadStaticMubin();
+    s32 x_6();
+    void x_5();
+    s64 traverseStuff(sead::Vector3f vec, map::PlacementActors* pa, int a4);
+
+    phys::BodyGroup* getFieldBodyGroup(u32 a2);
+    void cleanupPhysics();
+    bool loadStaticCompound(int wl_0, bool a3, bool a4);
+    s32 x_2(s32 a2);
+    void x(int a2, map::Object* obj);
+    void unloadHksc(s32 a2);
+    s32 x_4(s64 a2);
+    s32 x_1(s64 a2);
+    bool staticCompoundStuff(s32 scId, bool cleanup);
+    s64 cleanHkscMaybe(s32 a2);
+    bool sub_7100D43F18(sead::Vector3f* pos);
+    void doDisableObjStaticCompound(map::Object* obj, bool disable);
+    void x_9();
+
+    void x_7(int idx, int a3, char column, char row, sead::SafeString* mubinPath,
+             sead::SafeString* folderAndFile, int a8, bool a9);
+
+    enum {
+        InitStatus_None = 0,
+        InitStatus_StaticLoaded = 1,
+        InitStatus_DynamicLoadStarted = 2,
+        InitStatus_DynamicLoaded = 3,
+        InitStatus_4 = 4,
+        InitStatus_5 = 5,  // x_9 takes initStatus from 4 to 5 in pmm->updateHkscLoadStatuesMaybe()
+
+    };
+
+    u16 skipLoadStaticMap;
+    u16 staticMapLoaded;
+    u16 _04;
+    s16 _06;
+    sead::FixedSafeString<128> mubinPath;         // 008
+    sead::FixedSafeString<128> folderAndFile;     // 0a0
+    u32 idx;                                      //
+    sead::SafeArray<PlacementMapHkscRes, 4> res;  // 140
+    ksys::res::Handle staticMubinRes;             // 2a0
+    ksys::res::Handle dynamicMubinRes;            // 2f0
+    s32 dynamicGroupIdx;                          // 340
+    s32 parsedNumStaticObjs;                      // 344
+    s32 numStaticObjs;                            // 348
+    u32 initStatus;                               // 34c
+    s8 col;                                       // 350
+    s8 row;                                       // 351
+    u16 field_352;                                // 352
+    sead::Matrix34f mat;                          // 354
+    s32 distanceToCurrentMapUnit;                 // 384
+    u32 _388;                                     // 388 check x_7() called ....
+    u32 _38c;                                     // 38c ... from MapMgr::ctor (a8)
+    ksys::map::PlacementActors* pa;               // 390
+    ksys::map::PlacementMapMgr* mgr;              // 398
+    void* p18;                                    // 3a0
+    sead::Buffer<void*> routes;                   // 3a8 Raw Object Data
+    s32 numRoutes;                                // 3b8
+    s32 gap_38c;                                  // 3bc
+    sead::CriticalSection cs;                     // 3c0
+};
+
+KSYS_CHECK_SIZE_NX150(PlacementMap, 0x400);
+
+/* NOT WORKING */
+class PlacementMapMgrMapArray {
+public:
+    PlacementMapMgrMapArray() = default;
+    ~PlacementMapMgrMapArray() = default;
+
+    sead::PtrArray<PlacementMap> maps; /* 0x00 */
+    sead::PtrArray<PlacementMap> ptrs; /* 0x10 */
+    map::PlacementActors* pa;          /* 0x20 */
+    s64 _28;                           /* 0x28 */
+    ksys::res::Handle res;             /* 0x30 */
+    Placement18* p18;                  /* 0x80 */
+    s32 _88;                           /* 0x88 */
+    s32 _8c;                           /* 0x8c */
+    void* _90;                         /* 0x90 */
+};
+KSYS_CHECK_SIZE_NX150(PlacementMapMgrMapArray, 0x98);
+
+/* NOT WORKING */
+class PlacementMapMgr {
+    SEAD_SINGLETON_DISPOSER(PlacementMapMgr)
+public:
+    PlacementMapMgr() = default;
+    ~PlacementMapMgr() = default;
+
+    void junk();  // Here to make compiler include MapPlacement - REMOVE
+
+    s32 numMaps;                                 /* 0x00 */
+    s32 _4;                                      /* 0x04 */
+    ksys::map::PlacementMap* maps;               /* 0x08 */
+    ksys::map::MapProperties* mapProps;          /* 0x10 */
+    s32 _18;                                     /* 0x18 */
+    s32 _1c;                                     /* 0x1c */
+    ksys::map::PlacementMapMgrMapArray mapArray; /* 0x20 */
+    ksys::map::FarActorMerge* farActorMerge;     /* 0xB8 */
+    s32 needLoadDynMap;                          /* 0xC0 */
+    s32 needLoadDynMapPhysics;                   /* 0xC4 */
+    char isShrineOrDivineBeast;                  /* 0xC8 */
+    char isShrine;                               /* 0xC9 */
+    char _ca[6];                                 /* 0xCA */
+};
+/* Size - D0 ? */
+KSYS_CHECK_SIZE_NX150(PlacementMapMgr, 0xF0);
+
+}  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -1,91 +1,72 @@
 #pragma once
 
+#include <basis/seadTypes.h>
 #include <container/seadBuffer.h>
 #include <container/seadPtrArray.h>
-#include <heap/seadDisposer.h>
-#include <heap/seadExpHeap.h>
+#include <container/seadSafeArray.h>
+#include <heap/seadHeap.h>
 #include <math/seadMatrix.h>
+#include <prim/seadSafeString.h>
 #include "KingSystem/Map/mapPlacementActors.h"
+#include "KingSystem/Map/mapPlacementMapMgr.h"
 #include "KingSystem/Physics/StaticCompound/physStaticCompound.h"
 #include "KingSystem/Resource/resHandle.h"
+#include "KingSystem/Utils/Types.h"
 
 namespace ksys::map {
 
-class PlacementMapMgr; /* See Below */
-class MapProperties;
-class Placement18;
-class FarActorMerge;
-
-class PlacementMapHkscRes {
-    enum {
-        Status_2 = 2,  // Call cleanupHkscMaybe(), if ok, set to 3
-        Status_3 = 3,
-        Status_4 = 4,  // Call staticCompoundStuff, if ok, set to 5
-        Status_5 = 5,
-    };
-
-public:
-    PlacementMapHkscRes() = default;
-    ~PlacementMapHkscRes() = default;
-
-    ksys::res::Handle res;
-    s32 statusMaybe;
-    bool _54;
-    bool _55;
-    bool _56;
-    bool _57;
-
-    void cleanup() {
-        auto r = res.getResource();
-        if (auto ptr = sead::DynamicCast<ksys::phys::StaticCompound>(r)) {
-            if (ptr->calledFromMapDtor()) {
-                ptr->cleanUp();
-            }
-        }
-    }
-};
-KSYS_CHECK_SIZE_NX150(PlacementMapHkscRes, 0x58);
+class PlacementMapMgr;
 
 class PlacementMap {
-    enum { StaticMap_None = 0, StaticMap_Loaded = 1 << 0, StaticMap_Parsed = 1 << 8 };
-
 public:
-    __attribute__((noinline)) PlacementMap() {
-        initStatus = PlacementMap::InitStatus_None;
-        parsedNumStaticObjs = 0xFFFFFFFF;
-        staticMapLoaded = StaticMap_None;
-        numStaticObjs = 0xFFFFFFFF;
-        mat = sead::Matrix34f::ident;
-        distanceToCurrentMapUnit = 0;
-        skipLoadStaticMap = 0;
-        _38c = 0xFFFFFFFF;
-        idx = 0;
-        _388 = 0;
-        col = 0;
-        row = 0;
-        numRoutes = 0;
-        p18 = 0;
-        mgr = 0;
-        pa = 0;
-        dynamicGroupIdx = 0xFFFFFFFF;
-        res[0].statusMaybe = 0;
-        res[1].statusMaybe = 0;
-        res[2].statusMaybe = 0;
-        res[3].statusMaybe = 0;
-    };
+    struct HkscRes {
+        enum class Status {
+            _0 = 0,
+            _1 = 1,
+            _2 = 2,  // Call cleanupHkscMaybe(), if ok, set to 3
+            _3 = 3,
+            _4 = 4,  // Call staticCompoundStuff, if ok, set to 5
+            _5 = 5,
+        };
 
-    ~PlacementMap() {
-        routes.freeBuffer();
-        for (auto& r : res) {
-            r.cleanup();
+        HkscRes() = default;
+        ~HkscRes() = default;
+
+        res::Handle mRes;
+        Status mStatus;
+        // bool _pad[4];
+
+        void cleanup() {
+            auto* r = mRes.getResource();
+            if (auto sc = sead::DynamicCast<phys::StaticCompound>(r)) {
+                if (sc->calledFromMapDtor()) {
+                    sc->cleanUp();
+                }
+            }
         }
-    }
+    };
+    KSYS_CHECK_SIZE_NX150(HkscRes, 0x58);
 
-    s32 loadStaticMap_(u8 load);
+    // This enum is used on a u16. enum classses are 32 bit
+    enum { StaticMap_None = 0, StaticMap_Loaded = 1 << 0, StaticMap_Parsed = 1 << 8 };
+    enum class InitStatus {
+        None = 0,
+        StaticLoaded = 1,
+        DynamicLoadStarted = 2,
+        DynamicLoaded = 3,
+        _4 = 4,
+        _5 = 5,  // x_9 takes initStatus from 4 to 5 in pmm->updateHkscLoadStatuesMaybe()
+    };
+    KSYS_CHECK_SIZE_NX150(InitStatus, 4);
+
+    PlacementMap();
+    ~PlacementMap();
+
+    s32 loadStaticMap_(bool load);
     void doLoadStaticMap_(bool load);
 
-    bool parseStaticMap_(sead::ExpHeap* heap, u8* data);
-    void parseMap_(sead::ExpHeap* heap, u8* data, int group, u32 idx);
+    bool parseStaticMap_(sead::Heap* heap, u8* data);
+    void parseMap_(sead::Heap* heap, u8* data, int group, u32 idx);
 
     bool loadDynamicMap();
 
@@ -96,109 +77,55 @@ public:
     void unloadStaticMubin();
     s32 x_6();
     void x_5();
-    s64 traverseStuff(sead::Vector3f vec, map::PlacementActors* pa, int a4);
+    s64 traverseStuff(sead::Vector3f* vec, PlacementActors* pa, int id);
 
-    phys::BodyGroup* getFieldBodyGroup(u32 a2);
+    phys::BodyGroup* getFieldBodyGroup(u32 field_body_group_id);
     void cleanupPhysics();
-    bool loadStaticCompound(int wl_0, bool a3, bool a4);
-    s32 x_2(s32 a2);
-    void x(int a2, map::Object* obj);
-    void unloadHksc(s32 a2);
-    s32 x_4(s64 a2);
-    s32 x_1(s64 a2);
-    bool staticCompoundStuff(s32 scId, bool cleanup);
-    s64 cleanHkscMaybe(s32 a2);
-    bool sub_7100D43F18(sead::Vector3f* pos);
-    void doDisableObjStaticCompound(map::Object* obj, bool disable);
+    bool loadStaticCompound(int id, bool is_auto_gen_mu, bool load_maybe);
+    s32 x_2(s32 id);
+    void x(int id, Object* obj);
+    void unloadHksc(s32 id);
+    s32 x_4(s64 id);
+    s32 x_1(s64 id);
+    bool staticCompoundStuff(s32 sc_id, bool cleanup);
+    s64 cleanHkscMaybe(s32 id);
+    bool sub_7100D43F18(sead::Vector3f& pos);
+    void doDisableObjStaticCompound(Object* obj, bool disable);
     void x_9();
 
-    void x_7(int idx, int a3, char column, char row, sead::SafeString* mubinPath,
-             sead::SafeString* folderAndFile, int a8, bool a9);
+    void x_7(int idx, int unknown, char column, char row, sead::SafeString* mubinPath,
+             sead::SafeString* folderAndFile, int map_id_maybe, bool skip_load_static_map);
 
-    enum {
-        InitStatus_None = 0,
-        InitStatus_StaticLoaded = 1,
-        InitStatus_DynamicLoadStarted = 2,
-        InitStatus_DynamicLoaded = 3,
-        InitStatus_4 = 4,
-        InitStatus_5 = 5,  // x_9 takes initStatus from 4 to 5 in pmm->updateHkscLoadStatuesMaybe()
-
-    };
-
-    u16 skipLoadStaticMap;
-    u16 staticMapLoaded;
+    u16 mSkipLoadStaticMap;
+    u16 mStaticMapLoaded;
     u16 _04;
     s16 _06;
-    sead::FixedSafeString<128> mubinPath;         // 008
-    sead::FixedSafeString<128> folderAndFile;     // 0a0
-    u32 idx;                                      //
-    sead::SafeArray<PlacementMapHkscRes, 4> res;  // 140
-    ksys::res::Handle staticMubinRes;             // 2a0
-    ksys::res::Handle dynamicMubinRes;            // 2f0
-    s32 dynamicGroupIdx;                          // 340
-    s32 parsedNumStaticObjs;                      // 344
-    s32 numStaticObjs;                            // 348
-    u32 initStatus;                               // 34c
-    s8 col;                                       // 350
-    s8 row;                                       // 351
-    u16 field_352;                                // 352
-    sead::Matrix34f mat;                          // 354
-    s32 distanceToCurrentMapUnit;                 // 384
-    u32 _388;                                     // 388 check x_7() called ....
-    u32 _38c;                                     // 38c ... from MapMgr::ctor (a8)
-    ksys::map::PlacementActors* pa;               // 390
-    ksys::map::PlacementMapMgr* mgr;              // 398
-    void* p18;                                    // 3a0
-    sead::Buffer<void*> routes;                   // 3a8 Raw Object Data
-    s32 numRoutes;                                // 3b8
-    s32 gap_38c;                                  // 3bc
-    sead::CriticalSection cs;                     // 3c0
+    sead::FixedSafeString<128> mMubinPath;
+    sead::FixedSafeString<128> mFolderAndFile;
+    u32 mIdx;
+    sead::SafeArray<HkscRes, 4> mRes;
+    res::Handle mStaticMubinRes;
+    res::Handle mDynamicMubinRes;
+    s32 mDynamicGroupIdx;
+    s32 mParsedNumStaticObjs;
+    s32 mNumStaticObjs;
+    InitStatus mInitStatus;
+    s8 mCol;
+    s8 mRow;
+    u16 _352;
+    sead::Matrix34f mMat;
+    s32 mDistanceToCurrentMapUnit;
+    u32 _388;  // 388 check x_7() called ....
+    u32 _38c;  // 38c ... from MapMgr::ctor (a8)
+    PlacementActors* mPa;
+    PlacementMapMgr* mMgr;
+    void* mP18;
+    sead::Buffer<void*> mRoutes;
+    s32 mNumRoutes;
+    s32 gap_38c;
+    sead::CriticalSection mCs;
 };
 
 KSYS_CHECK_SIZE_NX150(PlacementMap, 0x400);
-
-/* NOT WORKING */
-class PlacementMapMgrMapArray {
-public:
-    PlacementMapMgrMapArray() = default;
-    ~PlacementMapMgrMapArray() = default;
-
-    sead::PtrArray<PlacementMap> maps; /* 0x00 */
-    sead::PtrArray<PlacementMap> ptrs; /* 0x10 */
-    map::PlacementActors* pa;          /* 0x20 */
-    s64 _28;                           /* 0x28 */
-    ksys::res::Handle res;             /* 0x30 */
-    Placement18* p18;                  /* 0x80 */
-    s32 _88;                           /* 0x88 */
-    s32 _8c;                           /* 0x8c */
-    void* _90;                         /* 0x90 */
-};
-KSYS_CHECK_SIZE_NX150(PlacementMapMgrMapArray, 0x98);
-
-/* NOT WORKING */
-class PlacementMapMgr {
-    SEAD_SINGLETON_DISPOSER(PlacementMapMgr)
-public:
-    PlacementMapMgr() = default;
-    ~PlacementMapMgr() = default;
-
-    void junk();  // Here to make compiler include MapPlacement - REMOVE
-
-    s32 numMaps;                                 /* 0x00 */
-    s32 _4;                                      /* 0x04 */
-    ksys::map::PlacementMap* maps;               /* 0x08 */
-    ksys::map::MapProperties* mapProps;          /* 0x10 */
-    s32 _18;                                     /* 0x18 */
-    s32 _1c;                                     /* 0x1c */
-    ksys::map::PlacementMapMgrMapArray mapArray; /* 0x20 */
-    ksys::map::FarActorMerge* farActorMerge;     /* 0xB8 */
-    s32 needLoadDynMap;                          /* 0xC0 */
-    s32 needLoadDynMapPhysics;                   /* 0xC4 */
-    char isShrineOrDivineBeast;                  /* 0xC8 */
-    char isShrine;                               /* 0xC9 */
-    char _ca[6];                                 /* 0xCA */
-};
-/* Size - D0 ? */
-KSYS_CHECK_SIZE_NX150(PlacementMapMgr, 0xF0);
 
 }  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -18,9 +18,9 @@ namespace ksys::map {
 class PlacementMapMgr;
 
 class PlacementMap {
-public:
     struct HkscRes {
-        enum class Status {
+    public:
+        enum class Status : int {
             _0 = 0,
             _1 = 1,
             _2 = 2,  // Call cleanupHkscMaybe(), if ok, set to 3
@@ -32,10 +32,6 @@ public:
         HkscRes() = default;
         ~HkscRes() = default;
 
-        res::Handle mRes;
-        Status mStatus;
-        // bool _pad[4];
-
         void cleanup() {
             auto* r = mRes.getResource();
             if (auto sc = sead::DynamicCast<phys::StaticCompound>(r)) {
@@ -44,12 +40,14 @@ public:
                 }
             }
         }
+
+        res::Handle mRes;
+        Status mStatus;
     };
     KSYS_CHECK_SIZE_NX150(HkscRes, 0x58);
 
-    // This enum is used on a u16. enum classses are 32 bit
-    enum { StaticMap_None = 0, StaticMap_Loaded = 1 << 0, StaticMap_Parsed = 1 << 8 };
-    enum class InitStatus {
+    enum class StaticMap : u16 { None = 0, Loaded = 1 << 0, Parsed = 1 << 8 };
+    enum class InitStatus : int {
         None = 0,
         StaticLoaded = 1,
         DynamicLoadStarted = 2,
@@ -59,10 +57,12 @@ public:
     };
     KSYS_CHECK_SIZE_NX150(InitStatus, 4);
 
+public:
     PlacementMap();
     ~PlacementMap();
 
-    s32 loadStaticMap_(bool load);
+private:
+    int loadStaticMap_(bool load);
     void doLoadStaticMap_(bool load);
 
     bool parseStaticMap_(sead::Heap* heap, u8* data);
@@ -70,34 +70,34 @@ public:
 
     bool loadDynamicMap();
 
-    s32 parseDynamicMap();
+    int parseDynamicMap();
 
     void resetDynamic();
     void unload();
     void unloadStaticMubin();
-    s32 x_6();
+    int x_6();
     void x_5();
-    s64 traverseStuff(sead::Vector3f* vec, PlacementActors* pa, int id);
+    int traverseStuff(sead::Vector3f* vec, PlacementActors* pa, int id);
 
-    phys::BodyGroup* getFieldBodyGroup(u32 field_body_group_id);
+    phys::BodyGroup* getFieldBodyGroup(u32 field_body_group_index);
     void cleanupPhysics();
-    bool loadStaticCompound(int id, bool is_auto_gen_mu, bool load_maybe);
-    s32 x_2(s32 id);
+    bool loadStaticCompound(int index, bool is_auto_gen_mu, bool load_maybe);
+    int x_2(int id);
     void x(int id, Object* obj);
-    void unloadHksc(s32 id);
-    s32 x_4(s64 id);
-    s32 x_1(s64 id);
-    bool staticCompoundStuff(s32 sc_id, bool cleanup);
-    s64 cleanHkscMaybe(s32 id);
-    bool sub_7100D43F18(sead::Vector3f& pos);
+    void unloadHksc(int id);
+    int x_4(int id);
+    int x_1(int id);
+    bool staticCompoundStuff(int sc_id, bool cleanup);
+    int cleanHkscMaybe(int id);
+    bool sub_7100D43F18(const sead::Vector3f& pos);
     void doDisableObjStaticCompound(Object* obj, bool disable);
     void x_9();
 
-    void x_7(int idx, int unknown, char column, char row, sead::SafeString* mubinPath,
-             sead::SafeString* folderAndFile, int map_id_maybe, bool skip_load_static_map);
+    void x_7(int idx, int unknown, char column, char row, const sead::SafeString& mubinPath,
+             const sead::SafeString& folderAndFile, int map_id_maybe, bool skip_load_static_map);
 
     u16 mSkipLoadStaticMap;
-    u16 mStaticMapLoaded;
+    StaticMap mStaticMapLoaded;
     u16 _04;
     s16 _06;
     sead::FixedSafeString<128> mMubinPath;
@@ -106,23 +106,23 @@ public:
     sead::SafeArray<HkscRes, 4> mRes;
     res::Handle mStaticMubinRes;
     res::Handle mDynamicMubinRes;
-    s32 mDynamicGroupIdx;
-    s32 mParsedNumStaticObjs;
-    s32 mNumStaticObjs;
+    int mDynamicGroupIdx;
+    int mParsedNumStaticObjs;
+    int mNumStaticObjs;
     InitStatus mInitStatus;
     s8 mCol;
     s8 mRow;
     u16 _352;
     sead::Matrix34f mMat;
-    s32 mDistanceToCurrentMapUnit;
+    int mDistanceToCurrentMapUnit;
     u32 _388;  // 388 check x_7() called ....
     u32 _38c;  // 38c ... from MapMgr::ctor (a8)
     PlacementActors* mPa;
     PlacementMapMgr* mMgr;
     void* mP18;
     sead::Buffer<void*> mRoutes;
-    s32 mNumRoutes;
-    s32 gap_38c;
+    int mNumRoutes;
+    int gap_38c;
     sead::CriticalSection mCs;
 };
 

--- a/src/KingSystem/Map/mapPlacementMapMgr.cpp
+++ b/src/KingSystem/Map/mapPlacementMapMgr.cpp
@@ -1,0 +1,7 @@
+#include "KingSystem/Map/mapPlacementMapMgr.h"
+
+namespace ksys::map {
+
+SEAD_SINGLETON_DISPOSER_IMPL(PlacementMapMgr)
+
+}  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMapMgr.cpp
+++ b/src/KingSystem/Map/mapPlacementMapMgr.cpp
@@ -1,7 +1,3 @@
 #include "KingSystem/Map/mapPlacementMapMgr.h"
 
-namespace ksys::map {
-
-SEAD_SINGLETON_DISPOSER_IMPL(PlacementMapMgr)
-
-}  // namespace ksys::map
+namespace ksys::map {}  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMapMgr.h
+++ b/src/KingSystem/Map/mapPlacementMapMgr.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <heap/seadDisposer.h>
+#include "KingSystem/Map/mapPlacementMap.h"
+#include "KingSystem/Resource/resHandle.h"
+#include "KingSystem/Utils/Types.h"
+
+namespace ksys::map {
+
+class MapProperties;
+class Placement18;
+class FarActorMerge;
+
+class PlacementMap;
+
+/* NOT WORKING */
+class PlacementMapArray {
+public:
+    PlacementMapArray() = default;
+    ~PlacementMapArray() = default;
+
+    sead::PtrArray<PlacementMap> mMaps;
+    sead::PtrArray<PlacementMap> mPtrs;
+    PlacementActors* mPa;
+    s64 _28;
+    res::Handle mRes;
+    Placement18* mP18;
+    s32 _88;
+    s32 _8c;
+    void* _90;
+};
+KSYS_CHECK_SIZE_NX150(PlacementMapArray, 0x98);
+
+/* NOT WORKING */
+class PlacementMapMgr {
+    SEAD_SINGLETON_DISPOSER(PlacementMapMgr)
+
+public:
+    PlacementMapMgr() = default;
+    ~PlacementMapMgr() = default;
+
+    void junk();  // Here to make compiler include MapPlacement - REMOVE
+
+    s32 mNumMaps;
+    s32 _4;
+    PlacementMap* mMaps;
+    MapProperties* mMapProps;
+    s32 _18;
+    s32 _1c;
+    PlacementMapArray mMapArray;
+    FarActorMerge* mFarActorMerge;
+    s32 mNeedLoadDynMap;
+    s32 mNeedLoadDynMapPhysics;
+    bool mIsShrineOrDivineBeast;
+    bool mIsShrine;
+    // char pad[6];
+};
+/* Size - D0 ? */
+KSYS_CHECK_SIZE_NX150(PlacementMapMgr, 0xF0);
+
+}  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMapMgr.h
+++ b/src/KingSystem/Map/mapPlacementMapMgr.h
@@ -16,33 +16,30 @@ class FarActorMerge;
 class PlacementMap;
 
 /* NOT WORKING */
-class PlacementMapArray {
-public:
-    PlacementMapArray() = default;
-    ~PlacementMapArray() = default;
-
-    sead::PtrArray<PlacementMap> mMaps;
-    sead::PtrArray<PlacementMap> mPtrs;
-    PlacementActors* mPa;
-    s64 _28;
-    res::Handle mRes;
-    Placement18* mP18;
-    s32 _88;
-    s32 _8c;
-    void* _90;
-};
-KSYS_CHECK_SIZE_NX150(PlacementMapArray, 0x98);
-
-/* NOT WORKING */
 class PlacementMapMgr {
-    SEAD_SINGLETON_DISPOSER(PlacementMapMgr)
+    /* NOT WORKING */
+    class PlacementMapArray {
+    public:
+        PlacementMapArray() = default;
+        ~PlacementMapArray() = default;
+
+        sead::PtrArray<PlacementMap> mMaps;
+        sead::PtrArray<PlacementMap> mPtrs;
+        PlacementActors* mPa;
+        s64 _28;
+        res::Handle mRes;
+        Placement18* mP18;
+        s32 _88;
+        s32 _8c;
+        void* _90;
+    };
+    KSYS_CHECK_SIZE_NX150(PlacementMapArray, 0x98);
 
 public:
     PlacementMapMgr() = default;
     ~PlacementMapMgr() = default;
 
-    void junk();  // Here to make compiler include MapPlacement - REMOVE
-
+private:
     s32 mNumMaps;
     s32 _4;
     PlacementMap* mMaps;
@@ -55,9 +52,8 @@ public:
     s32 mNeedLoadDynMapPhysics;
     bool mIsShrineOrDivineBeast;
     bool mIsShrine;
-    // char pad[6];
 };
-/* Size - D0 ? */
-KSYS_CHECK_SIZE_NX150(PlacementMapMgr, 0xF0);
+
+KSYS_CHECK_SIZE_NX150(PlacementMapMgr, 0xD0);
 
 }  // namespace ksys::map

--- a/src/KingSystem/Map/mapPlacementMapMgr.h
+++ b/src/KingSystem/Map/mapPlacementMapMgr.h
@@ -40,9 +40,7 @@ public:
     ~PlacementMapMgr() = default;
 
 private:
-    s32 mNumMaps;
-    s32 _4;
-    PlacementMap* mMaps;
+    sead::Buffer<PlacementMap> mMaps;
     MapProperties* mMapProps;
     s32 _18;
     s32 _1c;

--- a/src/KingSystem/Map/mapPlacementMapMgr.h
+++ b/src/KingSystem/Map/mapPlacementMapMgr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <container/seadBuffer.h>
 #include <container/seadPtrArray.h>
 #include <heap/seadDisposer.h>
 #include "KingSystem/Map/mapPlacementMap.h"

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompound.h
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompound.h
@@ -41,6 +41,9 @@ public:
     bool finishParsing_() override;
     bool m7_() override;
 
+    void cleanUp();
+    bool calledFromMapDtor();
+
 private:
     enum class Flag {
         Initialised = 1 << 0,


### PR DESCRIPTION
Added 
- PlacementMap class
- PlacementMapMgr class stub
- PlacementMapMgrMapArray class stub

Includes "OK" functions
- PlacementMap::PlacementMap
- PlacementMap::~PlacementMap

**Note:** I needed to include a `junk()` function to make sure PlacementMap ctor and dtor were included in the executable.  There is probably a more elegant method of doing this.

*Getting tired of typing Placement*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/75)
<!-- Reviewable:end -->
