### PR TITLE
Added x_0, x_4(); change u16 mStaticCompoundId to s16 mStaticCompundActorId

### DIFF
--- a/src/KingSystem/Map/mapObject.cpp
+++ b/src/KingSystem/Map/mapObject.cpp
@@ -61,7 +61,7 @@ void Object::initData(MubinIter* iter, u8 idx, u32 actor_data_idx, ActorData* da
     mFlags.makeAllZero();
     mIdx = 0;
     mNumLinksPointingToMe = 0;
-    mStaticCompoundId = 0xFFFF;
+    mStaticCompoundActorId = -1;
     _18 = nullptr;
     _20 = nullptr;
     _10 = nullptr;
@@ -88,7 +88,7 @@ void Object::initData(MubinIter* iter, u8 idx, u32 actor_data_idx, ActorData* da
     _10 = nullptr;
     _18 = nullptr;
     _20 = nullptr;
-    mStaticCompoundId = 0xFFFF;
+    mStaticCompoundActorId = -1;
     mActorDataIdx = actor_data_idx;
     mProc = nullptr;
     mLinkData = nullptr;

--- a/src/KingSystem/Map/mapObject.h
+++ b/src/KingSystem/Map/mapObject.h
@@ -40,6 +40,7 @@ public:
         _100 = 0x100,
         ActorCreated = 0x200,
         _400 = 0x400,
+        _800 = 0x800,
         _2000 = 0x2000,
         _4000 = 0x4000,
         _8000 = 0x8000,
@@ -187,7 +188,8 @@ public:
     auto getActorDataIdx() const { return mActorDataIdx; }
     auto getIdx() const { return mIdx; }
     auto getId() const { return mId; }
-    auto getStaticCompoundId() const { return mStaticCompoundId; }
+    auto getStaticCompoundActorId() const { return mStaticCompoundActorId; }
+    void setStaticCompoundActorId(s16 id) { mStaticCompoundActorId = id; }
 
     const ActorData& getActorData() const {
         return PlacementMgr::instance()->mPlacementActors->mActorData[mActorDataIdx];
@@ -215,7 +217,7 @@ private:
     sead::TypedBitFlag<ActorFlag8, u8> mActorFlags8;
     u8 _b = 0xff;
     u16 mId = 0;
-    u16 mStaticCompoundId = 0xffff;
+    s16 mStaticCompoundActorId = -1;
     void* _10 = nullptr;
     void* _18 = nullptr;
     void* _20 = nullptr;

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -105,9 +105,10 @@ private:
     void x_7(int idx, int unknown, s8 column, s8 row, const sead::SafeString& mubin_path,
              const sead::SafeString& folder_and_file, int map_id_maybe, bool skip_load_static_map);
 
-    int getStaticCompoundIdFromPosition(const sead::Vector3f& pos) const;
-    int getStaticCompoundIdFromPosition(float x, float z) const;
-    int getStaticCompoundIdFromPosition2(const sead::Vector3f& pos) const;
+    int getStaticCompoundActorIdFromPosition(const sead::Vector3f& pos) const;
+    int getStaticCompoundActorIdFromPosition(float x, float z) const;
+    int getStaticCompoundActorIdFromPosition(const Object& object) const;
+
     u8 _0;
     u8 mSkipLoadStaticMap;
     bool mStaticMapLoaded;

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -92,9 +92,9 @@ private:
     void cleanupPhysics();
     bool loadStaticCompound(int hksc_idx, bool is_auto_gen_mu, bool req_arg_8);
     MapObjStatus x_2(int hksc_idx);
-    void x_0(int id, Object* obj);
+    void updateObjectCollisionAndId(int id, Object* obj);
     void unloadHksc(int hksc_idx);
-    int x_4(int id);
+    bool clearStaticCompoundActorId(int id);
     int x_1(int id);
     bool staticCompoundStuff(int sc_id, bool cleanup);
     int doSomethingStaticCompound(int hksc_idx);
@@ -106,7 +106,8 @@ private:
              const sead::SafeString& folder_and_file, int map_id_maybe, bool skip_load_static_map);
 
     int getStaticCompoundIdFromPosition(const sead::Vector3f& pos) const;
-
+    int getStaticCompoundIdFromPosition(float x, float z) const;
+    int getStaticCompoundIdFromPosition2(const sead::Vector3f& pos) const;
     u8 _0;
     u8 mSkipLoadStaticMap;
     bool mStaticMapLoaded;

--- a/src/KingSystem/Map/mapPlacementMap.h
+++ b/src/KingSystem/Map/mapPlacementMap.h
@@ -105,9 +105,9 @@ private:
     void x_7(int idx, int unknown, s8 column, s8 row, const sead::SafeString& mubin_path,
              const sead::SafeString& folder_and_file, int map_id_maybe, bool skip_load_static_map);
 
-    int getStaticCompoundActorIdFromPosition(const sead::Vector3f& pos) const;
-    int getStaticCompoundActorIdFromPosition(float x, float z) const;
-    int getStaticCompoundActorIdFromPosition(const Object& object) const;
+    int getStaticCompoundIdFromPosition(const sead::Vector3f& pos) const;
+    int getStaticCompoundIdFromPosition(float x, float z) const;
+    int getStaticCompoundIdFromPosition(const Object& object) const;
 
     u8 _0;
     u8 mSkipLoadStaticMap;

--- a/src/KingSystem/Map/mapPlacementMgr.h
+++ b/src/KingSystem/Map/mapPlacementMgr.h
@@ -55,6 +55,7 @@ public:
     bool someFlagCheck() const;
 
     void threadFn(sead::Thread* thread, sead::MessageQueue::Element msg);
+    // 0x00000071011eb4dc
     bool auto17(Object* obj);
 
     enum class MgrFlag {

--- a/src/KingSystem/Map/mapPlacementMgr.h
+++ b/src/KingSystem/Map/mapPlacementMgr.h
@@ -55,6 +55,7 @@ public:
     bool someFlagCheck() const;
 
     void threadFn(sead::Thread* thread, sead::MessageQueue::Element msg);
+    bool auto17(Object* obj);
 
     enum class MgrFlag {
         _1 = 0x1,

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompound.cpp
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompound.cpp
@@ -62,11 +62,11 @@ void StaticCompound::doCreate_(u8* buffer, u32 buffer_size, sead::Heap* parent_h
     mHeap->adjust();
 }
 
-void StaticCompound::setMapObject(u32 hash_id, u32 srt_hash, map::Object* object) {
+int StaticCompound::setMapObject(u32 hash_id, u32 srt_hash, map::Object* object) {
     int idx = mStaticCompoundInfo->getActorIdx(hash_id, srt_hash);
-    if (idx < 0 || idx >= mMapObjects.size())
-        return;
-    mMapObjects[idx] = object;
+    if (idx >= 0 && idx < mMapObjects.size())
+        mMapObjects[idx] = object;
+    return idx;
 }
 
 map::Object* StaticCompound::getMapObject(int shape_idx) const {

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompound.h
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompound.h
@@ -27,7 +27,7 @@ public:
     StaticCompound();
     ~StaticCompound() override;
 
-    void setMapObject(u32 hash_id, u32 srt_hash, map::Object* object);
+    int setMapObject(u32 hash_id, u32 srt_hash, map::Object* object);
     map::Object* getMapObject(int shape_idx) const;
 
     bool disableCollision(int actor_idx, bool x);


### PR DESCRIPTION
Added `x_0` and `x_4()` in `ksys::map::PlacementMap`

- `x_0()` => `updateObjectCollisionAndId()`
- `x_4()` => `clearStaticCompoundActorId()`

Changed `u16 mStaticCompoundId` to `s16 mStaticCompundActorId` in `ksys::map::Object`

Change `void StaticCompound::setMapObject()` to `int StaticCompound::setMapObject()`

The addition of `int PlacementMap::getStaticCompoundIdFromPosition(float x, float z) const` broke one of the existing functions so I created an alternative that looked like the original.  I am certain there is a better way to do this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/85)
<!-- Reviewable:end -->
