### PR TITLE
ksys/phys: Implement `SphereShape` and `SphereRigidBody`

### DIFF
--- a/lib/hkStubs/CMakeLists.txt
+++ b/lib/hkStubs/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(hkStubs OBJECT
   Havok/Physics2012/Collide/Shape/Convex/Box/hkpBoxShape.h
   Havok/Physics2012/Collide/Shape/Convex/Capsule/hkpCapsuleShape.h
   Havok/Physics2012/Collide/Shape/Convex/ConvexTransform/hkpConvexTransformShape.h
+  Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h
   Havok/Physics2012/Collide/Shape/Convex/ConvexVertices/hkpConvexVerticesShape.h
   Havok/Physics2012/Collide/Shape/Convex/Cylinder/hkpCylinderShape.h
   Havok/Physics2012/Collide/Shape/Convex/Sphere/hkpSphereShape.h

--- a/lib/hkStubs/Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h
+++ b/lib/hkStubs/Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h
@@ -13,28 +13,28 @@ public:
         const hkpConvexShape* childShape, const hkVector4& translation,
         hkpShapeContainer::ReferencePolicy ref = hkpShapeContainer::REFERENCE_POLICY_INCREMENT);
 
-    inline const hkpConvexShape* getChildShape() const;
-    virtual void getSupportingVertex(hkVector4Parameter direction,
-                                     hkcdVertex& supportingVertexOut) const;
-    virtual void convertVertexIdsToVertices(const hkpVertexId* ids, int numIds,
-                                            hkcdVertex* verticesOut) const;
-    virtual void getCentre(hkVector4& centreOut) const;
-    virtual HK_FORCE_INLINE int getNumCollisionSpheres() const;
-    virtual const hkSphere* getCollisionSpheres(hkSphere* sphereBuffer) const;
-    virtual void getAabb(const hkTransform& localToWorld, hkReal tolerance, hkAabb& out) const;
-    virtual hkBool castRay(const hkpShapeRayCastInput& input, hkpShapeRayCastOutput& results) const;
-    virtual void castRayWithCollector(const hkpShapeRayCastInput& input, const hkpCdBody& cdBody,
-                                      hkpRayHitCollector& collector) const;
+    void getSupportingVertex(hkVector4Parameter direction,
+                             hkcdVertex& supportingVertexOut) const override;
+    void convertVertexIdsToVertices(const hkpVertexId* ids, int numIds,
+                                    hkcdVertex* verticesOut) const override;
+    void getCentre(hkVector4& centreOut) const override;
+    HK_FORCE_INLINE int getNumCollisionSpheres() const override;
+    const hkSphere* getCollisionSpheres(hkSphere* sphereBuffer) const override;
+    void getAabb(const hkTransform& localToWorld, hkReal tolerance, hkAabb& out) const override;
+    hkBool castRay(const hkpShapeRayCastInput& input,
+                   hkpShapeRayCastOutput& results) const override;
+    void castRayWithCollector(const hkpShapeRayCastInput& input, const hkpCdBody& cdBody,
+                              hkpRayHitCollector& collector) const override;
+    void getFirstVertex(hkVector4& v) const override;
+    hkReal getMaximumProjection(const hkVector4& direction) const override;
+    const hkpShapeContainer* getContainer() const override;
+    int calcSizeForSpu(const CalcSizeForSpuInput& input, int spuBufferSizeLeft) const override;
 
+    inline const hkpConvexShape* getChildShape() const;
     inline hkVector4& getTranslation();
     inline const hkVector4& getTranslation() const;
 
     hkpConvexTranslateShape(class hkFinishLoadedObjectFlag flag);
-
-    virtual void getFirstVertex(hkVector4& v) const;
-    virtual hkReal getMaximumProjection(const hkVector4& direction) const;
-    virtual const hkpShapeContainer* getContainer() const;
-    virtual int calcSizeForSpu(const CalcSizeForSpuInput& input, int spuBufferSizeLeft) const;
 
 protected:
     hkVector4 m_translation;

--- a/lib/hkStubs/Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h
+++ b/lib/hkStubs/Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <Havok/Physics2012/Collide/Shape/Convex/hkpConvexShape.h>
+
+class hkpConvexTranslateShape : public hkpConvexTransformShapeBase {
+public:
+    HK_DECLARE_CLASS_ALLOCATOR(hkpConvexTranslateShape)
+    HK_DECLARE_REFLECTION()
+    HKCD_DECLARE_SHAPE_TYPE(hkcdShapeType::CONVEX_TRANSLATE)
+
+    HK_FORCE_INLINE hkpConvexTranslateShape() {}
+    HK_FORCE_INLINE hkpConvexTranslateShape(
+        const hkpConvexShape* childShape, const hkVector4& translation,
+        hkpShapeContainer::ReferencePolicy ref = hkpShapeContainer::REFERENCE_POLICY_INCREMENT);
+
+    inline const hkpConvexShape* getChildShape() const;
+    virtual void getSupportingVertex(hkVector4Parameter direction,
+                                     hkcdVertex& supportingVertexOut) const;
+    virtual void convertVertexIdsToVertices(const hkpVertexId* ids, int numIds,
+                                            hkcdVertex* verticesOut) const;
+    virtual void getCentre(hkVector4& centreOut) const;
+    virtual HK_FORCE_INLINE int getNumCollisionSpheres() const;
+    virtual const hkSphere* getCollisionSpheres(hkSphere* sphereBuffer) const;
+    virtual void getAabb(const hkTransform& localToWorld, hkReal tolerance, hkAabb& out) const;
+    virtual hkBool castRay(const hkpShapeRayCastInput& input, hkpShapeRayCastOutput& results) const;
+    virtual void castRayWithCollector(const hkpShapeRayCastInput& input, const hkpCdBody& cdBody,
+                                      hkpRayHitCollector& collector) const;
+
+    inline hkVector4& getTranslation();
+    inline const hkVector4& getTranslation() const;
+
+    hkpConvexTranslateShape(class hkFinishLoadedObjectFlag flag);
+
+    virtual void getFirstVertex(hkVector4& v) const;
+    virtual hkReal getMaximumProjection(const hkVector4& direction) const;
+    virtual const hkpShapeContainer* getContainer() const;
+    virtual int calcSizeForSpu(const CalcSizeForSpuInput& input, int spuBufferSizeLeft) const;
+
+protected:
+    hkVector4 m_translation;
+};
+
+HK_FORCE_INLINE
+hkpConvexTranslateShape::hkpConvexTranslateShape(const hkpConvexShape* childShape,
+                                                 const hkVector4& translation,
+                                                 hkpShapeContainer::ReferencePolicy ref)
+    : hkpConvexTransformShapeBase(HKCD_SHAPE_TYPE_FROM_CLASS(hkpConvexTranslateShape),
+                                  childShape->getRadius(), childShape, ref) {
+    hkVector4 t = translation;
+    t.setW(0);
+    m_translation = t;
+    m_childShapeSizeForSpu = 0;
+}
+
+inline const hkpConvexShape* hkpConvexTranslateShape::getChildShape() const {
+    return static_cast<const hkpConvexShape*>(m_childShape.getChild());
+}
+
+inline const hkVector4& hkpConvexTranslateShape::getTranslation() const {
+    return m_translation;
+}
+
+inline hkVector4& hkpConvexTranslateShape::getTranslation() {
+    return m_translation;
+}
+
+HK_FORCE_INLINE int hkpConvexTranslateShape::getNumCollisionSpheres() const {
+    return getChildShape()->getNumCollisionSpheres();
+}

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.cpp
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.cpp
@@ -1,1 +1,76 @@
 #include "KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.h"
+#include <Havok/Physics2012/Dynamics/Entity/hkpRigidBody.h>
+#include "KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h"
+
+namespace ksys::phys {
+
+SphereRigidBody* SphereRigidBody::make(RigidBodyInstanceParam* param, sead::Heap* heap) {
+    return createSphere(param, heap);
+}
+
+SphereRigidBody::SphereRigidBody(hkpRigidBody* hk_body, SphereShape* shape,
+                                 ContactLayerType layer_type, const sead::SafeString& name,
+                                 bool set_flag_10, sead::Heap* heap)
+    : RigidBodyFromShape(hk_body, layer_type, name, set_flag_10, heap), mShape(shape) {}
+
+SphereRigidBody::~SphereRigidBody() {
+    if (hasFlag(RigidBody::Flag::_10) && mShape) {
+        delete mShape;
+        mShape = nullptr;
+    }
+}
+
+void SphereRigidBody::setRadius(const float radius) {
+    if (mShape->setRadius(radius))
+        updateShape();
+}
+
+void SphereRigidBody::setTranslate(const sead::Vector3f& translate) {
+    if (mShape->setTranslate(translate))
+        updateShape();
+}
+
+float SphereRigidBody::getRadius() const {
+    return mShape->mRadius;
+}
+
+const sead::Vector3f& SphereRigidBody::getTranslate() const {
+    return mShape->mTranslate;
+}
+
+void SphereRigidBody::getTransformedTranslate(sead::Vector3f* translate) {
+    lock();
+    const auto& transform = getHkBody()->getMotion()->getMotionState()->getTransform();
+    unlock();
+    mShape->getTranslate(translate, transform);
+}
+
+void SphereRigidBody::setMaterialMask(const MaterialMask& mask) {
+    mShape->setMaterialMask(mask);
+}
+
+const MaterialMask& SphereRigidBody::getMaterialMask() const {
+    return mShape->mMaterialMask;
+}
+
+float SphereRigidBody::getVolume() {
+    return mShape->getVolume();
+}
+
+Shape* SphereRigidBody::getShape_() {
+    return mShape;
+}
+
+const Shape* SphereRigidBody::getShape_() const {
+    return mShape;
+}
+
+u32 SphereRigidBody::getCollisionMasks(RigidBody::CollisionMasks* masks, const u32* unk,
+                                       const sead::Vector3f& contact_point) {
+    masks->ignored_layers = ~mContactMask.getDirect();
+    masks->collision_filter_info = getCollisionFilterInfo();
+    masks->material_mask = getMaterialMask().getRawData();
+    return 0;
+}
+
+}  // namespace ksys::phys

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.cpp
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.cpp
@@ -20,7 +20,7 @@ SphereRigidBody::~SphereRigidBody() {
     }
 }
 
-void SphereRigidBody::setRadius(const float radius) {
+void SphereRigidBody::setRadius(float radius) {
     if (mShape->setRadius(radius))
         updateShape();
 }

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.h
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.h
@@ -16,7 +16,7 @@ public:
     ~SphereRigidBody() override;
 
     /// Set the sphere radius and trigger a shape update.
-    void setRadius(const float radius);
+    void setRadius(float radius);
     /// Set the sphere translation and trigger a shape update.
     void setTranslate(const sead::Vector3f& translate);
 

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.h
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereRigidBody.h
@@ -15,11 +15,19 @@ public:
                     const sead::SafeString& name, bool set_flag_10, sead::Heap* heap);
     ~SphereRigidBody() override;
 
+    /// Set the sphere radius and trigger a shape update.
+    void setRadius(const float radius);
+    /// Set the sphere translation and trigger a shape update.
+    void setTranslate(const sead::Vector3f& translate);
+
+    float getRadius() const;
+    const sead::Vector3f& getTranslate() const;
+    void getTransformedTranslate(sead::Vector3f* translate);
+
+    void setMaterialMask(const MaterialMask& mask);
     const MaterialMask& getMaterialMask() const;
 
     float getVolume() override;
-
-    void setRadius(float radius);
 
 protected:
     Shape* getShape_() override;

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.cpp
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.cpp
@@ -1,1 +1,157 @@
 #include "KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h"
+#include "KingSystem/Physics/physConversions.h"
+#include "KingSystem/Utils/HeapUtil.h"
+#include "KingSystem/Utils/SafeDelete.h"
+
+namespace ksys::phys {
+
+SphereShape* SphereShape::make(const SphereShapeParam& param, sead::Heap* heap) {
+    hkpSphereShape* sphere = nullptr;
+    if (auto* storage = heap->alloc(sizeof(hkpSphereShape), 0x10)) {
+        sphere = new (storage) hkpSphereShape(param.radius);
+    }
+
+    hkpConvexTranslateShape* translate_shape = nullptr;
+    if (auto* storage = util::allocStorage<hkpConvexTranslateShape>(heap)) {
+        translate_shape = new (storage) hkpConvexTranslateShape(sphere, toHkVec4(param.translate));
+
+        if (sphere != nullptr) {
+            return new (heap) SphereShape(param, sphere, translate_shape);
+        }
+    }
+
+    if (sphere) {
+        delete reinterpret_cast<u8*>(sphere);
+    } else if (translate_shape) {
+        delete reinterpret_cast<u8*>(translate_shape);
+    }
+
+    return (SphereShape*)nullptr;
+}
+
+SphereShape* SphereShape::clone(sead::Heap* heap) const {
+    SphereShapeParam param;
+
+    param.radius = mRadius;
+    param.translate = mTranslate;
+
+    auto* cloned = make(param, heap);
+    cloned->setMaterialMask(mMaterialMask);
+    return cloned;
+}
+
+SphereShape::SphereShape(const SphereShapeParam& param, hkpSphereShape* shape,
+                         hkpConvexTranslateShape* translate_shape)
+    : mRadius(param.radius), mHavokShape(shape), mTranslate(param.translate),
+      mMaterialMask(param.common.getMaterialMask()), mTranslateShape(translate_shape) {
+    const bool no_transform = mTranslate == sead::Vector3f(0, 0, 0);
+    mFlags.change(Flag::HasTransform, !no_transform);
+
+    if (param.common.item_code_disable_stick)
+        mMaterialMask.getData().setCustomFlag(MaterialMaskData::CustomFlag::_0);
+
+    setMaterialMask(mMaterialMask);
+}
+
+SphereShape::~SphereShape() {
+    util::deallocateObjectUnsafe(mHavokShape);
+    util::deallocateObjectUnsafe(mTranslateShape);
+}
+
+void SphereShape::setMaterialMask(const MaterialMask& mask) {
+    mMaterialMask = mask;
+
+    if (mHavokShape)
+        mHavokShape->setUserData(mask.getRawData());
+
+    if (mTranslateShape)
+        mTranslateShape->setUserData(mask.getRawData());
+}
+
+float SphereShape::getVolume() const {
+    return 4 / 3 * sead::Mathf::pi() * mRadius * mRadius * mRadius;
+}
+
+hkpShape* SphereShape::getHavokShape() {
+    if (mFlags.isOn(Flag::HasTransform))
+        return mTranslateShape;
+
+    return mHavokShape;
+};
+
+const hkpShape* SphereShape::getHavokShape() const {
+    if (mFlags.isOn(Flag::HasTransform))
+        return mTranslateShape;
+    return mHavokShape;
+};
+
+const hkpShape* SphereShape::updateHavokShape() {
+    if (mFlags.isOn(Flag::Dirty)) {
+        {
+            const auto ref_count = mHavokShape->getReferenceCount();
+            mHavokShape = new (mHavokShape) hkpSphereShape(mRadius);
+            mHavokShape->setReferenceCount(ref_count);
+        }
+        {
+            const auto ref_count = mTranslateShape->getReferenceCount();
+            mTranslateShape =
+                new (mTranslateShape) hkpConvexTranslateShape(mHavokShape, toHkVec4(mTranslate));
+            mTranslateShape->setReferenceCount(ref_count);
+        }
+
+        setMaterialMask(mMaterialMask);
+        mFlags.reset(Flag::Dirty);
+    }
+
+    if (mFlags.isOn(Flag::DirtyTransform)) {
+        mFlags.reset(Flag::DirtyTransform);
+        return getHavokShapeConst();
+    }
+
+    return nullptr;
+};
+
+bool SphereShape::setRadius(float radius) {
+    if (radius == mRadius || radius <= 0.0f) {
+        return false;
+    }
+
+    mRadius = radius;
+    mFlags.set(Flag::Dirty);
+    return true;
+}
+
+void SphereShape::setScale(float scale) {
+    setRadius(mRadius * scale);
+    setTranslate(mTranslate * scale);
+}
+
+bool SphereShape::setTranslate(const sead::Vector3f& translate) {
+    if (mTranslate == translate)
+        return false;
+
+    mTranslate = translate;
+
+    const bool had_transform = mFlags.isOn(Flag::HasTransform);
+    const bool no_transform = translate == sead::Vector3f(0, 0, 0);
+
+    mFlags.change(Flag::HasTransform, !no_transform);
+    mFlags.change(Flag::DirtyTransform, had_transform != !no_transform);
+    mFlags.set(Flag::Dirty);
+
+    return true;
+}
+
+void SphereShape::getTranslate(sead::Vector3f* out, const hkTransformf& transform) const {
+    hkVector4f translate;
+    if (mFlags.isOn(Flag::HasTransform)) {
+        hkVector4f transformed;
+        transformed.setTransformedPos(transform, toHkVec4(mTranslate));
+        translate = transformed;
+    } else {
+        translate = transform.getTranslation();
+    }
+    storeToVec3(out, translate);
+}
+
+}  // namespace ksys::phys

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.cpp
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.cpp
@@ -2,6 +2,10 @@
 #include "KingSystem/Physics/physConversions.h"
 #include "KingSystem/Utils/HeapUtil.h"
 #include "KingSystem/Utils/SafeDelete.h"
+#include "math/seadMathCalcCommon.h"
+
+#include <Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h>
+#include <Havok/Physics2012/Collide/Shape/Convex/Sphere/hkpSphereShape.h>
 
 namespace ksys::phys {
 
@@ -26,7 +30,7 @@ SphereShape* SphereShape::make(const SphereShapeParam& param, sead::Heap* heap) 
         delete reinterpret_cast<u8*>(translate_shape);
     }
 
-    return (SphereShape*)nullptr;
+    return nullptr;
 }
 
 SphereShape* SphereShape::clone(sead::Heap* heap) const {

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h
@@ -1,11 +1,15 @@
 #pragma once
 
-#include <Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h>
-#include <Havok/Physics2012/Collide/Shape/Convex/Sphere/hkpSphereShape.h>
 #include <math/seadVector.h>
+#include <prim/seadTypedBitFlag.h>
+#include <thread/seadAtomic.h>
 #include "KingSystem/Physics/RigidBody/Shape/physShape.h"
 #include "KingSystem/Physics/RigidBody/physRigidBody.h"
 #include "KingSystem/Physics/RigidBody/physRigidBodyParam.h"
+
+class hkpSphereShape;
+class hkpConvexTranslateShape;
+class hkTransformf;
 
 namespace ksys::phys {
 

--- a/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h
+++ b/src/KingSystem/Physics/RigidBody/Shape/Sphere/physSphereShape.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Havok/Physics2012/Collide/Shape/Convex/ConvexTranslate/hkpConvexTranslateShape.h>
+#include <Havok/Physics2012/Collide/Shape/Convex/Sphere/hkpSphereShape.h>
 #include <math/seadVector.h>
 #include "KingSystem/Physics/RigidBody/Shape/physShape.h"
 #include "KingSystem/Physics/RigidBody/physRigidBody.h"
@@ -18,15 +20,45 @@ struct SphereShapeParam {
 class SphereShape : public Shape {
     SEAD_RTTI_OVERRIDE(SphereShape, Shape)
 public:
+    enum class Flag {
+        /// Whether there is a pending change.
+        Dirty = 1 << 0,
+        /// Whether we have a transform (translation and/or rotation).
+        HasTransform = 1 << 1,
+        /// Whether there is a pending transform change.
+        DirtyTransform = 1 << 2,
+    };
+
     static SphereShape* make(const SphereShapeParam& param, sead::Heap* heap);
+
+    SphereShape(const SphereShapeParam& param, hkpSphereShape* shape,
+                hkpConvexTranslateShape* translate_shape);
+    ~SphereShape() override;
+
     SphereShape* clone(sead::Heap* heap) const;
 
+    bool setTranslate(const sead::Vector3f& translate);
+    bool setRadius(float radius);
     void setMaterialMask(const MaterialMask& mask);
     const MaterialMask& getMaterialMask() const { return mMaterialMask; }
 
-private:
-    char _8[0x28 - 0x8];
+    ShapeType getType() const override { return ShapeType::Sphere; }
+    float getVolume() const override;
+    hkpShape* getHavokShape() override;
+    const hkpShape* getHavokShape() const override;
+    const hkpShape* updateHavokShape() override;
+    void setScale(float scale) override;
+
+    /// Get the transform's translation or mTranslate transformed by the matrix
+    /// (if we have a non-zero translation vector).
+    void getTranslate(sead::Vector3f* out, const hkTransformf& transform) const;
+
+    float mRadius;
+    hkpSphereShape* mHavokShape{};
+    sead::TypedBitFlag<Flag, sead::Atomic<u32>> mFlags;
+    sead::Vector3f mTranslate;
     MaterialMask mMaterialMask;
+    hkpConvexTranslateShape* mTranslateShape{};
 };
 
 class SphereParam : public RigidBodyInstanceParam, public SphereShapeParam {


### PR DESCRIPTION
As per the title. Additionally, this PR adds a header for `hkpConvexTranslateShape` (which is a dependency of SphereShape)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/92)
<!-- Reviewable:end -->
