### PR TITLE
Rename `removeItem` to `removeFairy`

### DIFF
--- a/src/Game/UI/uiPauseMenuDataMgr.cpp
+++ b/src/Game/UI/uiPauseMenuDataMgr.cpp
@@ -1121,7 +1121,7 @@ PauseMenuDataMgr::deleteItem_(const sead::OffsetList<PouchItem>& list, PouchItem
     updateListHeads();
 }
 
-void PauseMenuDataMgr::removeItem(const sead::SafeString& name) {
+void PauseMenuDataMgr::removeFairy(const sead::SafeString& name) {
     const auto lock = sead::makeScopedLock(mCritSection);
     const auto& items = getItems();
 

--- a/src/Game/UI/uiPauseMenuDataMgr.h
+++ b/src/Game/UI/uiPauseMenuDataMgr.h
@@ -273,7 +273,7 @@ public:
     /// If type is PouchItemType::Invalid, all inventory items will be unequipped.
     void unequipAll(PouchItemType type = PouchItemType::Invalid);
 
-    void removeItem(const sead::SafeString& name);
+    void removeFairy(const sead::SafeString& name);
     void removeWeaponIfEquipped(const sead::SafeString& name);
     void removeArrow(const sead::SafeString& arrow_name, int count = 1);
 


### PR DESCRIPTION
`uking::ui::PauseMenuDataMgr::removeItem` is only called by `Player::tryReviveBeforeGameOver`, in order to find the first slot containing a fairy to remove upon taking fatal damage. `removeFairy` is therefore a more fitting name for this function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/124)
<!-- Reviewable:end -->
