### PR TITLE
doAddToPouch

### DIFF
--- a/src/Game/UI/uiPauseMenuDataMgr.h
+++ b/src/Game/UI/uiPauseMenuDataMgr.h
@@ -195,6 +195,7 @@ public:
 
     PouchItemType getType() const { return mType; }
     bool isEquipped() const { return mEquipped; }
+    void setEquipped(bool equipped) { mEquipped = equipped; }
     bool isInInventory() const { return mInInventory; }
     const sead::SafeString& getName() const { return mName; }
     ItemUse getItemUse() const { return mItemUse; }
@@ -417,6 +418,15 @@ private:
             item->~PouchItem();
             new (item) PouchItem;
             list2.pushFront(item);
+        }
+
+        PouchItem* pushNewItem() {
+            auto* item = list2.popFront();
+            if (!item) {
+                return nullptr;
+            }
+            list1.pushBack(item);
+            return item;
         }
 
         sead::OffsetList<PouchItem> list1;


### PR DESCRIPTION
The setItemModifier inlined helper had to be re-written to match

The switch statement is pretty weird. I am pretty sure the armor case should be part of the switch, but looks like the arrow case is not. However, when I do that the codegen is completely different. Maybe some inline function is in play, but I tried many things that didn't work

Update: matched by changing `<=1` to `<=0` in Sword branch and using a setter for mEquipped (Thanks to @TheGreatB3 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/139)
<!-- Reviewable:end -->
