### PR TITLE
style: clean up redundant virtual

### DIFF
--- a/src/Game/Damage/dmgStruct20.h
+++ b/src/Game/Damage/dmgStruct20.h
@@ -32,7 +32,7 @@ public:
 
     void reset() override;
 
-    __attribute__((noinline)) virtual void combineMaybe(Struct20Base* other) override;
+    __attribute__((noinline)) void combineMaybe(Struct20Base* other) override;
 
     // Unknown which fields belong in Struct20 vs Struct20Base
     u32 mField_8 = 0;

--- a/src/KingSystem/World/worldShootingStarMgr.h
+++ b/src/KingSystem/World/worldShootingStarMgr.h
@@ -10,12 +10,12 @@ namespace ksys::world {
 class ShootingStarMgr : public Job {
 public:
     ShootingStarMgr();
-    virtual ~ShootingStarMgr();
+    ~ShootingStarMgr() override;
 
     JobType getType() const override { return JobType::ShootingStar; }
 
-    virtual void init_(sead::Heap* heap) override;
-    virtual void calc_() override;
+    void init_(sead::Heap* heap) override;
+    void calc_() override;
     virtual void reset();
 
     static void setScheduled(bool enable);


### PR DESCRIPTION
**Changes:**
- [worldShootingStarMgr.h](cci:7://file:///c:/botw/src/KingSystem/World/worldShootingStarMgr.h:0:0-0:0): removed `virtual` from [init_()](cci:1://file:///c:/botw/src/KingSystem/World/worldJob.h:32:4-32:43) and [calc_()](cci:1://file:///c:/botw/src/KingSystem/World/worldJob.h:33:4-33:27) which already have `override`
- [dmgStruct20.h](cci:7://file:///c:/botw/src/Game/Damage/dmgStruct20.h:0:0-0:0): removed `virtual` from `Struct20::combineMaybe()` which already has `override`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/156)
<!-- Reviewable:end -->
