### PR TITLE
various: fix mismatches in some action stubs and ResourceMgrTask

### DIFF
--- a/src/Game/AI/Action/actionOff.cpp
+++ b/src/Game/AI/Action/actionOff.cpp
@@ -28,7 +28,8 @@ void Off::loadParams_() {
 }
 
 void Off::calc_() {
-    ActionEx::calc_();
+    if (isFinishedAS(*mTargetIdx_s, *mSeqBankIdx_s))
+        setFinished();
 }
 
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionOn.cpp
+++ b/src/Game/AI/Action/actionOn.cpp
@@ -28,7 +28,8 @@ void On::loadParams_() {
 }
 
 void On::calc_() {
-    ActionEx::calc_();
+    if (isFinishedAS(*mTargetIdx_s, *mSeqBankIdx_s))
+        setFinished();
 }
 
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionPlayerStoleOpenBase.cpp
+++ b/src/Game/AI/Action/actionPlayerStoleOpenBase.cpp
@@ -21,7 +21,8 @@ void PlayerStoleOpenBase::loadParams_() {
 }
 
 void PlayerStoleOpenBase::calc_() {
-    ActionEx::calc_();
+    if (isFinishedAS(0, 0))
+        setFinished();
 }
 
 }  // namespace uking::action

--- a/src/KingSystem/Resource/resResourceMgrTask.cpp
+++ b/src/KingSystem/Resource/resResourceMgrTask.cpp
@@ -681,7 +681,9 @@ void ResourceMgrTask::setCompactionStopped(bool stopped) {
         old_counter = mCompactionCounter.increment();
 
     stubbedLogFunction();
-    if (mCompactionCounter == 0 || old_counter == 0)
+    if (mCompactionCounter == 0)
+        stubbedLogFunction();
+    else if (old_counter == 0)
         stubbedLogFunction();
 }
 


### PR DESCRIPTION
## Changes

### action::On::calc_ and action::Off::calc_
- Replaced empty ActionEx::calc_() with isFinishedAS(*mTargetIdx_s, *mSeqBankIdx_s) + setFinished()

### action::PlayerStoleOpenBase::calc_
- Replaced stub ActionEx::calc_() with isFinishedAS(0, 0) + setFinished()

### ksys::res::ResourceMgrTask::setCompactionStopped
- Changed || to if/else if to fix register allocation ordering (two cbz swapped)

All functions updated from W/m to O in uking_functions.csv.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/171)
<!-- Reviewable:end -->
