### PR TITLE
Ragdoll: decompile internal state members at offset 0xc0-0x110

### DIFF
--- a/src/Game/AI/Action/actionAnmUpDownMove.cpp
+++ b/src/Game/AI/Action/actionAnmUpDownMove.cpp
@@ -29,4 +29,8 @@ void AnmUpDownMove::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool AnmUpDownMove::isFinished() const {
+    return const_cast<AnmUpDownMove*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionAnmUpDownMove.h
+++ b/src/Game/AI/Action/actionAnmUpDownMove.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionBlownOff.cpp
+++ b/src/Game/AI/Action/actionBlownOff.cpp
@@ -29,4 +29,8 @@ void BlownOff::calc_() {
     Ragdoll::calc_();
 }
 
+bool BlownOff::isChangeable() const {
+    return mChangeableState == 1;
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionBlownOff.h
+++ b/src/Game/AI/Action/actionBlownOff.h
@@ -17,6 +17,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isChangeable() const override;
     void calc_() override;
 
     // static_param at offset 0x118

--- a/src/Game/AI/Action/actionFreeMove.cpp
+++ b/src/Game/AI/Action/actionFreeMove.cpp
@@ -32,4 +32,8 @@ void FreeMove::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool FreeMove::isChangeable() const {
+    return *mIsChangeable_s;
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionFreeMove.h
+++ b/src/Game/AI/Action/actionFreeMove.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isChangeable() const override;
     void calc_() override;
 
     // FIXME: remove this

--- a/src/Game/AI/Action/actionGanonBarrierOn.cpp
+++ b/src/Game/AI/Action/actionGanonBarrierOn.cpp
@@ -26,4 +26,8 @@ void GanonBarrierOn::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool GanonBarrierOn::isFinished() const {
+    return const_cast<GanonBarrierOn*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGanonBarrierOn.h
+++ b/src/Game/AI/Action/actionGanonBarrierOn.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionGanonSmallDamage.cpp
+++ b/src/Game/AI/Action/actionGanonSmallDamage.cpp
@@ -28,4 +28,8 @@ void GanonSmallDamage::calc_() {
     SmallDamageBase::calc_();
 }
 
+bool GanonSmallDamage::isFinished() const {
+    return const_cast<GanonSmallDamage*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGanonSmallDamage.h
+++ b/src/Game/AI/Action/actionGanonSmallDamage.h
@@ -17,6 +17,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x90

--- a/src/Game/AI/Action/actionGanonThrowFireBall.cpp
+++ b/src/Game/AI/Action/actionGanonThrowFireBall.cpp
@@ -32,4 +32,8 @@ void GanonThrowFireBall::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool GanonThrowFireBall::isFinished() const {
+    return const_cast<GanonThrowFireBall*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGanonThrowFireBall.h
+++ b/src/Game/AI/Action/actionGanonThrowFireBall.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionGanonThrowTornado.cpp
+++ b/src/Game/AI/Action/actionGanonThrowTornado.cpp
@@ -32,4 +32,8 @@ void GanonThrowTornado::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool GanonThrowTornado::isFinished() const {
+    return const_cast<GanonThrowTornado*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGanonThrowTornado.h
+++ b/src/Game/AI/Action/actionGanonThrowTornado.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionGetUpBase.cpp
+++ b/src/Game/AI/Action/actionGetUpBase.cpp
@@ -28,4 +28,8 @@ void GetUpBase::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool GetUpBase::isFinished() const {
+    return const_cast<GetUpBase*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGetUpBase.h
+++ b/src/Game/AI/Action/actionGetUpBase.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // FIXME: remove this

--- a/src/Game/AI/Action/actionGuardianMiniFinalBeamMove.cpp
+++ b/src/Game/AI/Action/actionGuardianMiniFinalBeamMove.cpp
@@ -22,4 +22,8 @@ void GuardianMiniFinalBeamMove::calc_() {
     GuardianBeamFire::calc_();
 }
 
+bool GuardianMiniFinalBeamMove::isFinished() const {
+    return ksys::act::ai::Action::isFinished();
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionGuardianMiniFinalBeamMove.h
+++ b/src/Game/AI/Action/actionGuardianMiniFinalBeamMove.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 };
 

--- a/src/Game/AI/Action/actionOnetimeHoverASPlay.cpp
+++ b/src/Game/AI/Action/actionOnetimeHoverASPlay.cpp
@@ -28,4 +28,8 @@ void OnetimeHoverASPlay::calc_() {
     HoverBase::calc_();
 }
 
+bool OnetimeHoverASPlay::isFinished() const {
+    return const_cast<OnetimeHoverASPlay*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionOnetimeHoverASPlay.h
+++ b/src/Game/AI/Action/actionOnetimeHoverASPlay.h
@@ -17,6 +17,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x40

--- a/src/Game/AI/Action/actionRagdoll.h
+++ b/src/Game/AI/Action/actionRagdoll.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <math/seadVector.h>
 #include "KingSystem/ActorSystem/actAiAction.h"
 
 namespace uking::action {
@@ -52,6 +53,34 @@ protected:
     const sead::Vector3f* mDownBackCtrlOffset_s{};
     // static_param at offset 0xb8
     const sead::Vector3f* mDownFrontCtrlOffset_s{};
+    // ragdoll internal state at offset 0xc0
+    sead::Vector3f mRagdollForce{};
+    // ragdoll state at offset 0xcc
+    s32 mCounter1{};
+    s32 mCounter2{};
+    // ragdoll state at offset 0xd4
+    f32 mFloat1_d4{};
+    // ragdoll state at offset 0xd8
+    s32 mCounter3{};
+    s32 mCounter4{};
+    // ragdoll state at offset 0xe0
+    f32 mFloat2_e0{};
+    // ragdoll state at offset 0xe4
+    s32 mCounter5{};
+    s32 mCounter6{};
+    // ragdoll state at offset 0xec: checked by BlownOff::isChangeable()
+    s32 mChangeableState{};
+    // ragdoll state at offset 0xf0
+    f32 mFloat3_f0{};
+    f32 mFloat4_f4{};
+    // ragdoll state at offset 0xf8
+    void* mStatePtr_f8{};
+    // ragdoll state at offset 0x100
+    s32 mCounter7_100{};
+    // ragdoll state at offset 0x104
+    bool mFlag_104{};
+    // ragdoll state at offset 0x108
+    void* mStatePtr2_108{};
     // aitree_variable at offset 0x110
     void* mCRBOffsetUnit_a{};
 };

--- a/src/Game/AI/Action/actionSiteBossLswordAtk.cpp
+++ b/src/Game/AI/Action/actionSiteBossLswordAtk.cpp
@@ -42,4 +42,8 @@ void SiteBossLswordAtk::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool SiteBossLswordAtk::isFinished() const {
+    return const_cast<SiteBossLswordAtk*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionSiteBossLswordAtk.h
+++ b/src/Game/AI/Action/actionSiteBossLswordAtk.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionSiteBossSpearAttackBase.cpp
+++ b/src/Game/AI/Action/actionSiteBossSpearAttackBase.cpp
@@ -44,4 +44,8 @@ void SiteBossSpearAttackBase::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool SiteBossSpearAttackBase::isFinished() const {
+    return const_cast<SiteBossSpearAttackBase*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionSiteBossSpearAttackBase.h
+++ b/src/Game/AI/Action/actionSiteBossSpearAttackBase.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionSiteBossSwordAttackBase.cpp
+++ b/src/Game/AI/Action/actionSiteBossSwordAttackBase.cpp
@@ -40,4 +40,8 @@ void SiteBossSwordAttackBase::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool SiteBossSwordAttackBase::isFinished() const {
+    return const_cast<SiteBossSwordAttackBase*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionSiteBossSwordAttackBase.h
+++ b/src/Game/AI/Action/actionSiteBossSwordAttackBase.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionSiteBossThrowParts.cpp
+++ b/src/Game/AI/Action/actionSiteBossThrowParts.cpp
@@ -41,4 +41,8 @@ void SiteBossThrowParts::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool SiteBossThrowParts::isFinished() const {
+    return const_cast<SiteBossThrowParts*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionSiteBossThrowParts.h
+++ b/src/Game/AI/Action/actionSiteBossThrowParts.h
@@ -16,6 +16,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isFinished() const override;
     void calc_() override;
 
     // static_param at offset 0x20

--- a/src/Game/AI/Action/actionSmallDamage.cpp
+++ b/src/Game/AI/Action/actionSmallDamage.cpp
@@ -8,4 +8,8 @@ void SmallDamage::enter_(ksys::act::ai::InlineParamPack* params) {
     SmallDamageBase::enter_(params);
 }
 
+bool SmallDamage::isFinished() const {
+    return const_cast<SmallDamage*>(this)->isFinishedAS(0, 0);
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionSmallDamage.h
+++ b/src/Game/AI/Action/actionSmallDamage.h
@@ -13,6 +13,7 @@ public:
     void enter_(ksys::act::ai::InlineParamPack* params) override;
 
 protected:
+    bool isFinished() const override;
 };
 
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionStalEnemyBlownOff.cpp
+++ b/src/Game/AI/Action/actionStalEnemyBlownOff.cpp
@@ -45,4 +45,8 @@ void StalEnemyBlownOff::calc_() {
     ksys::act::ai::Action::calc_();
 }
 
+bool StalEnemyBlownOff::isChangeable() const {
+    return mChangeableState2 > 1;
+}
+
 }  // namespace uking::action

--- a/src/Game/AI/Action/actionStalEnemyBlownOff.h
+++ b/src/Game/AI/Action/actionStalEnemyBlownOff.h
@@ -15,6 +15,7 @@ public:
     void loadParams_() override;
 
 protected:
+    bool isChangeable() const override;
     void calc_() override;
 
     // static_param at offset 0x20
@@ -65,6 +66,17 @@ protected:
     const sead::Vector3f* mHeadShotAddVec_s{};
     // static_param at offset 0x128
     const sead::Vector3f* mHeadRotateOffset_s{};
+    u32 _130_1{};
+    u32 _130_2{};
+    u32 _130_3{};
+    u32 _130_4{};
+    u32 _130_5{};
+    u32 _130_6{};
+    u32 _130_7{};
+    u32 _130_8{};
+    u32 _130_9{};
+    // checked by isChangeable(): value > 1 means changeable (offset 0x154)
+    s32 mChangeableState2{};
 };
 
 }  // namespace uking::action


### PR DESCRIPTION
Fills the 80-byte gap in the Ragdoll class with 17 internal state
members. Adds isChangeable overrides for BlownOff, FreeMove and
StalEnemyBlownOff. Adds 14 isFinished overrides delegating to
isFinishedAS. Updates CSV: 15 U->O, 5 U->W, 2 W->O.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/176)
<!-- Reviewable:end -->
