### PR TITLE
Match Actor::getCharacterController

### DIFF
--- a/src/KingSystem/ActorSystem/actActor.cpp
+++ b/src/KingSystem/ActorSystem/actActor.cpp
@@ -3,6 +3,7 @@
 #include "KingSystem/ActorSystem/actAiRoot.h"
 #include "KingSystem/ActorSystem/actBaseProcLink.h"
 #include "KingSystem/ActorSystem/actBaseProcMgr.h"
+#include "KingSystem/Physics/System/physInstanceSet.h"
 
 namespace ksys::act {
 
@@ -79,6 +80,12 @@ int Actor::handleMessage(const Message& message) {
         m107();
         return 1;
     }
+}
+
+phys::CharacterController* Actor::getCharacterController() {
+    if (!mPhysics)
+        return nullptr;
+    return mPhysics->getCharacterController();
 }
 
 }  // namespace ksys::act

--- a/src/KingSystem/Physics/System/physInstanceSet.h
+++ b/src/KingSystem/Physics/System/physInstanceSet.h
@@ -58,6 +58,7 @@ public:
 
     const sead::SafeString& getName() const { return mName; }
     const ParamSet* getParamSet() const { return mParamSet; }
+    CharacterController* getCharacterController() const { return mCharacterController; }
 
     void setFlag2();
     void clothVisibleStuff();


### PR DESCRIPTION
Returns the controller held by the actor's phys::InstanceSet, or null when the
actor has no physics.

InstanceSet::mCharacterController is private, so this adds an inline accessor
alongside getName and getParamSet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/182)
<!-- Reviewable:end -->
