### PR TITLE
Match phys::System collision info forwarders

### DIFF
--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -67,6 +67,24 @@ void System::registerContactPointInfo(ContactPointInfo* info) const {
     mContactMgr->registerContactPointInfo(info);
 }
 
+CollisionInfo* System::allocCollisionInfo(sead::Heap* heap, const sead::SafeString& name) const {
+    return mContactMgr->makeCollisionInfo(heap, name);
+}
+
+void System::freeCollisionInfo(CollisionInfo* info) const {
+    mContactMgr->freeCollisionInfo(info);
+}
+
+ContactLayerCollisionInfoGroup*
+System::makeContactLayerCollisionInfoGroup(sead::Heap* heap, ContactLayer layer, int capacity,
+                                           const sead::SafeString& name) {
+    return mContactMgr->makeContactLayerCollisionInfoGroup(heap, layer, capacity, name);
+}
+
+void System::freeContactLayerCollisionInfoGroup(ContactLayerCollisionInfoGroup* group) {
+    mContactMgr->freeContactLayerCollisionInfoGroup(group);
+}
+
 RagdollControllerKeyList* System::getRagdollCtrlKeyList() const {
     if (!mSystemData)
         return nullptr;


### PR DESCRIPTION
allocCollisionInfo, freeCollisionInfo, makeContactLayerCollisionInfoGroup and
freeContactLayerCollisionInfoGroup each load mContactMgr and tail-call the
matching ContactMgr method, following the allocContactPointInfo pattern already
in the file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/183)
<!-- Reviewable:end -->
