### PR TITLE
Match phys::System contact listener and group handler forwarders

### DIFF
--- a/src/KingSystem/Physics/System/physLayerContactPointInfo.h
+++ b/src/KingSystem/Physics/System/physLayerContactPointInfo.h
@@ -84,6 +84,8 @@ public:
     bool registerLayerPair(ContactLayer layer1, ContactLayer layer2, bool enabled = true);
     bool isPairUnknown(ContactLayer layer1, ContactLayer layer2) const;
 
+    ContactLayerType getLayerType() const { return mLayerType; }
+
     ContactCallback* getCallback() const { return mCallback; }
     void setCallback(ContactCallback* callback) { mCallback = callback; }
 

--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -6,10 +6,12 @@
 #include "KingSystem/Physics/RigidBody/physRigidBodyResource.h"
 #include "KingSystem/Physics/StaticCompound/physStaticCompound.h"
 #include "KingSystem/Physics/SupportBone/physSupportBoneResource.h"
+#include "KingSystem/Physics/System/physContactListener.h"
 #include "KingSystem/Physics/System/physContactMgr.h"
 #include "KingSystem/Physics/System/physContactPointInfo.h"
 #include "KingSystem/Physics/System/physEntityGroupFilter.h"
 #include "KingSystem/Physics/System/physGroupFilter.h"
+#include "KingSystem/Physics/System/physLayerContactPointInfo.h"
 #include "KingSystem/Physics/System/physMaterialTable.h"
 #include "KingSystem/Physics/System/physRayCastRequestMgr.h"
 #include "KingSystem/Physics/System/physSensorGroupFilter.h"
@@ -51,6 +53,10 @@ void System::initSystemData(sead::Heap* heap) {
     mSystemData = new (heap) SystemData;
     mSystemData->load(mPhysicsSystemHeap, mEntityGroupFilter, mSensorGroupFilter, mMaterialTable,
                       mContactMgr);
+}
+
+void System::removeSystemGroupHandler(SystemGroupHandler* handler) {
+    mGroupFilters[static_cast<s32>(handler->getLayerType())]->removeSystemGroupHandler(handler);
 }
 
 ContactPointInfo* System::allocContactPointInfo(sead::Heap* heap, int num,
@@ -100,8 +106,25 @@ LayerContactPointInfo* System::allocLayerContactPointInfo(sead::Heap* heap, int 
     return mContactMgr->makeLayerContactPointInfo(heap, num, num2, name, a, b, c);
 }
 
+void System::freeLayerContactPointInfo(LayerContactPointInfo* info) const {
+    mContactListeners[static_cast<s32>(info->getLayerType())]->removeLayerPairsForContactPointInfo(
+        info);
+    mContactMgr->freeContactPointInfo(info);
+}
+
 void System::registerContactPointInfo(ContactPointInfo* info) const {
     mContactMgr->registerContactPointInfo(info);
+}
+
+void System::registerContactPointLayerPair(LayerContactPointInfo* info, ContactLayer layer1,
+                                           ContactLayer layer2, bool enabled) {
+    mContactListeners[static_cast<s32>(info->getLayerType())]->addLayerPairForContactPointInfo(
+        info, layer1, layer2, enabled);
+}
+
+ContactLayerCollisionInfo* System::trackLayerPair(ContactLayer layer_a, ContactLayer layer_b) {
+    return mContactListeners[static_cast<s32>(getContactLayerType(layer_a))]->trackLayerPair(
+        layer_a, layer_b);
 }
 
 RagdollControllerKeyList* System::getRagdollCtrlKeyList() const {

--- a/src/KingSystem/Physics/System/physSystem.h
+++ b/src/KingSystem/Physics/System/physSystem.h
@@ -14,6 +14,7 @@ namespace ksys::phys {
 class CollisionInfo;
 class ContactLayerCollisionInfo;
 class ContactLayerCollisionInfoGroup;
+class ContactListener;
 class ContactMgr;
 class ContactPointInfo;
 class GroupFilter;
@@ -151,8 +152,7 @@ private:
     GroupFilter* mEntityGroupFilter{};
     GroupFilter* mSensorGroupFilter{};
     sead::FixedPtrArray<GroupFilter, 2> mGroupFilters;
-    // FIXME: type
-    sead::FixedPtrArray<void*, 2> _128;
+    sead::FixedPtrArray<ContactListener, 2> mContactListeners;
     ContactMgr* mContactMgr;
     void* _150;
     StaticCompoundMgr* mStaticCompoundMgr;


### PR DESCRIPTION
The FIXME'd _128 is indexed by ContactLayerType and its elements take ContactListener calls, so it is sead::FixedPtrArray<ContactListener, 2>, named mContactListeners; the bounds check in the assembly is sead::PtrArrayImpl::at.

freeLayerContactPointInfo drops the info's layer pairs from the listener for its layer type, then frees the info through ContactMgr. registerContactPointLayerPair adds one pair to that same listener. trackLayerPair selects the listener from the first layer's ContactLayerType and returns the ContactLayerCollisionInfo it tracks.

removeSystemGroupHandler indexes mGroupFilters by the handler's layer type and forwards to GroupFilter::removeSystemGroupHandler.

I added getLayerType to LayerContactPointInfo since mLayerType is private.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/184)
<!-- Reviewable:end -->

