### PR TITLE
Match phys::System heap accessors

### DIFF
--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -1,4 +1,6 @@
 #include "KingSystem/Physics/System/physSystem.h"
+#include <heap/seadHeap.h>
+#include <thread/seadThread.h>
 #include "KingSystem/Physics/Cloth/physClothResource.h"
 #include "KingSystem/Physics/Ragdoll/physRagdollControllerKeyList.h"
 #include "KingSystem/Physics/Ragdoll/physRagdollResource.h"
@@ -14,6 +16,7 @@
 #include "KingSystem/Physics/System/physRayCastRequestMgr.h"
 #include "KingSystem/Physics/System/physSensorGroupFilter.h"
 #include "KingSystem/Physics/System/physSystemData.h"
+#include "KingSystem/Physics/physHavokMemoryAllocator.h"
 #include "KingSystem/Resource/resEntryFactory.h"
 #include "KingSystem/Resource/resSystem.h"
 
@@ -108,6 +111,24 @@ RagdollControllerKeyList* System::getRagdollCtrlKeyList() const {
     if (!mSystemData)
         return nullptr;
     return mSystemData->getRagdollCtrlKeyList();
+}
+
+bool System::isHavokMainHeapOom() const {
+    return static_cast<f32>(mHavokAllocator->getHeapFreeSize()) /
+               static_cast<f32>(mHavokAllocator->getHeapSize()) <
+           0.05f;
+}
+
+sead::Heap* System::getPhysicsTempHeap(LowPriority low_priority) const {
+    if (low_priority != LowPriority::No ||
+        sead::ThreadMgr::instance()->getCurrentThread()->getPriority() >
+            sead::Thread::cDefaultPriority)
+        return mPhysicsTempLowHeap;
+
+    if (mPhysicsTempDefaultHeap->getMaxAllocatableSize(8) <= 0x2800)
+        mPhysicsTempDefaultHeap->dump();
+
+    return mPhysicsTempDefaultHeap;
 }
 
 }  // namespace ksys::phys

--- a/src/KingSystem/Physics/System/physSystem.h
+++ b/src/KingSystem/Physics/System/physSystem.h
@@ -17,6 +17,7 @@ class ContactLayerCollisionInfoGroup;
 class ContactMgr;
 class ContactPointInfo;
 class GroupFilter;
+class HavokMemoryAllocator;
 class LayerContactPointInfo;
 class MaterialTable;
 class RayCastForRequest;
@@ -132,7 +133,8 @@ public:
     // 0x000000710121684c
     void decrementWorldUnkCounter(ContactLayerType layer_type);
 
-    // 0x0000007101216cec
+    bool isHavokMainHeapOom() const;
+
     sead::Heap* getPhysicsTempHeap(LowPriority low_priority) const;
 
 private:
@@ -144,7 +146,8 @@ private:
     float _6c = 1.0;
     float _70 = 1.0 / 30.0;
     float mTimeFactor{};
-    u8 _78[0xa8 - 0x78];
+    HavokMemoryAllocator* mHavokAllocator{};
+    u8 _80[0xa8 - 0x80];
     sead::CriticalSection mCS;
     void* _e8{};
     void* _f0{};


### PR DESCRIPTION
isHavokMainHeapOom returns true when the Havok main heap free size divided by its total size is below 0.05.

The allocator sits at this+0x78, inside the old _78 padding, so I added HavokMemoryAllocator* mHavokAllocator and shortened the padding to _80.

getPhysicsTempHeap returns mPhysicsTempDefaultHeap when low_priority is LowPriority::No and the current thread priority is at most sead::Thread::cDefaultPriority, dumping that heap first when getMaxAllocatableSize(8) is at most 0x2800. Every other case returns mPhysicsTempLowHeap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/185)
<!-- Reviewable:end -->
