### PR TITLE
Match physStaticCompoundUtil shape and collidable helpers

### DIFF
--- a/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.cpp
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.cpp
@@ -17,7 +17,8 @@ u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_colli
         return 1;
     };
 
-    if (shape.getType() == hkcdShapeType::BV_COMPRESSED_MESH) {
+    switch (shape.getType()) {
+    case hkcdShapeType::BV_COMPRESSED_MESH: {
         if (*shape_key == HK_INVALID_SHAPE_KEY)
             return no_material();
 
@@ -36,7 +37,7 @@ u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_colli
         return 0;
     }
 
-    if (shape.getType() == hkcdShapeType::STATIC_COMPOUND) {
+    case hkcdShapeType::STATIC_COMPOUND: {
         if (*shape_key == HK_INVALID_SHAPE_KEY)
             return no_material();
 
@@ -50,7 +51,7 @@ u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_colli
                                              &child_key);
     }
 
-    if (shape.getType() == hkcdShapeType::LIST) {
+    case hkcdShapeType::LIST: {
         if (*shape_key == HK_INVALID_SHAPE_KEY)
             return no_material();
 
@@ -60,8 +61,10 @@ u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_colli
                                              *list.getChildShape(*shape_key, buffer), shape_key);
     }
 
-    p_masks->material_mask = shape.getUserData();
-    return 0;
+    default:
+        p_masks->material_mask = shape.getUserData();
+        return 0;
+    }
 }
 
 void getBodyGroupAndObjectFromSCShape(StaticCompoundRigidBodyGroup** p_body_group,

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.cpp
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.cpp
@@ -1,1 +1,93 @@
 #include "KingSystem/Physics/StaticCompound/physStaticCompoundUtil.h"
+#include <Havok/Physics2012/Collide/Agent/Collidable/hkpCollidable.h>
+#include <Havok/Physics2012/Collide/Shape/Compound/Collection/List/hkpListShape.h>
+#include <Havok/Physics2012/Internal/Collide/BvCompressedMesh/hkpBvCompressedMeshShape.h>
+#include <Havok/Physics2012/Internal/Collide/StaticCompound/hkpStaticCompoundShape.h>
+#include "KingSystem/Physics/RigidBody/physRigidBody.h"
+#include "KingSystem/Physics/StaticCompound/physStaticCompoundMgr.h"
+#include "KingSystem/Physics/System/physSystem.h"
+
+namespace ksys::phys {
+
+u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_collision_filter_info,
+                                  const hkpShape& shape, const u32* shape_key) {
+    auto no_material = [&] {
+        p_masks->material_mask = 0;
+        *p_collision_filter_info = 0;
+        return 1;
+    };
+
+    if (shape.getType() == hkcdShapeType::BV_COMPRESSED_MESH) {
+        if (*shape_key == HK_INVALID_SHAPE_KEY)
+            return no_material();
+
+        const auto& mesh = static_cast<const hkpBvCompressedMeshShape&>(shape);
+        if (mesh.getCollisionFilterInfoMode() ==
+            hkpBvCompressedMeshShape::PER_PRIMITIVE_DATA_PALETTE) {
+            *p_collision_filter_info = mesh.getCollisionFilterInfo(*shape_key);
+        }
+
+        if (mesh.getUserDataMode() != hkpBvCompressedMeshShape::PER_PRIMITIVE_DATA_NONE) {
+            p_masks->material_mask = mesh.getPrimitiveUserData(*shape_key);
+            return 0;
+        }
+
+        p_masks->material_mask = mesh.getUserData();
+        return 0;
+    }
+
+    if (shape.getType() == hkcdShapeType::STATIC_COMPOUND) {
+        if (*shape_key == HK_INVALID_SHAPE_KEY)
+            return no_material();
+
+        const auto& compound = static_cast<const hkpStaticCompoundShape&>(shape);
+        int instance_id;
+        hkpShapeKey child_key;
+        compound.decomposeShapeKey(*shape_key, instance_id, child_key);
+        const auto& instance = compound.getInstances()[instance_id];
+        *p_collision_filter_info = compound.getCollisionFilterInfo(*shape_key);
+        return getMaterialMaskFromCollidable(p_masks, p_collision_filter_info, *instance.getShape(),
+                                             &child_key);
+    }
+
+    if (shape.getType() == hkcdShapeType::LIST) {
+        if (*shape_key == HK_INVALID_SHAPE_KEY)
+            return no_material();
+
+        hkpShapeBuffer buffer;
+        const auto& list = static_cast<const hkpListShape&>(shape);
+        return getMaterialMaskFromCollidable(p_masks, p_collision_filter_info,
+                                             *list.getChildShape(*shape_key, buffer), shape_key);
+    }
+
+    p_masks->material_mask = shape.getUserData();
+    return 0;
+}
+
+void getBodyGroupAndObjectFromSCShape(StaticCompoundRigidBodyGroup** p_body_group,
+                                      map::Object** p_object, const hkpShape& shape,
+                                      const u32* shape_key) {
+    if (shape.getType() != hkcdShapeType::STATIC_COMPOUND) {
+        *p_body_group = nullptr;
+        return;
+    }
+
+    auto* mgr = System::instance()->getStaticCompoundMgr();
+    if (!mgr) {
+        *p_body_group = nullptr;
+        return;
+    }
+
+    mgr->getBodyGroupAndMapObject(p_body_group, p_object,
+                                  static_cast<const hkpStaticCompoundShape&>(shape), shape_key);
+}
+
+u32 getCollisionFilterInfoFromCollidable(RigidBodyCollisionMasks* p_masks,
+                                         u32* p_collision_filter_info,
+                                         const hkpCollidable& collidable, const u32* shape_key) {
+    *p_collision_filter_info = collidable.getCollisionFilterInfo();
+    return getMaterialMaskFromCollidable(p_masks, p_collision_filter_info, *collidable.getShape(),
+                                         shape_key);
+}
+
+}  // namespace ksys::phys

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.h
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.h
@@ -20,8 +20,8 @@ u32 getMaterialMaskFromShape(const hkpShape& shape, const u32* shape_key,
                              const sead::Vector3f& position);
 
 // 0x0000007100fd086c
-bool getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_collision_filter_info,
-                                   const hkpShape& shape, const u32* shape_key);
+u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_collision_filter_info,
+                                  const hkpShape& shape, const u32* shape_key);
 
 // 0x0000007100fd09d0
 void getBodyGroupAndObjectFromSCShape(StaticCompoundRigidBodyGroup** p_body_group,

--- a/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.h
+++ b/src/KingSystem/Physics/StaticCompound/physStaticCompoundUtil.h
@@ -15,20 +15,16 @@ namespace ksys::phys {
 class StaticCompoundRigidBodyGroup;
 struct RigidBodyCollisionMasks;
 
-// 0x0000007100fd0810
 u32 getMaterialMaskFromShape(const hkpShape& shape, const u32* shape_key,
                              const sead::Vector3f& position);
 
-// 0x0000007100fd086c
 u32 getMaterialMaskFromCollidable(RigidBodyCollisionMasks* p_masks, u32* p_collision_filter_info,
                                   const hkpShape& shape, const u32* shape_key);
 
-// 0x0000007100fd09d0
 void getBodyGroupAndObjectFromSCShape(StaticCompoundRigidBodyGroup** p_body_group,
                                       map::Object** p_object, const hkpShape& shape,
                                       const u32* shape_key);
 
-// 0x0000007100fd0a1c
 u32 getCollisionFilterInfoFromCollidable(RigidBodyCollisionMasks* p_masks,
                                          u32* p_collision_filter_info,
                                          const hkpCollidable& collidable, const u32* shape_key);


### PR DESCRIPTION
getMaterialMaskFromCollidable was declared bool. A bool return makes clang append `and w0, w0, #0x1` at the shared exit, four bytes over the target, so it's a u32 now.

0x710164f960 is hkpBvCompressedMeshShape::getPrimitiveUserData, a Havok symbol the new code calls, so I moved it to L.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/186)
<!-- Reviewable:end -->
