### PR TITLE
Game/Damage: Implement DamageMgrShield

### DIFF
--- a/src/Game/Damage/CMakeLists.txt
+++ b/src/Game/Damage/CMakeLists.txt
@@ -2,6 +2,9 @@ target_sources(uking PRIVATE
     dmgDamageCallback.h
     dmgDamageManagerBase.h
     dmgDamageManagerBase.cpp
+    dmgDamageMgrShield.cpp
+    dmgDamageMgrShield.h
+    dmgDamageMgrWeapon.h
     dmgInfoManager.cpp
     dmgInfoManager.h
     dmgStruct20.h

--- a/src/Game/Damage/dmgDamageManagerBase.cpp
+++ b/src/Game/Damage/dmgDamageManagerBase.cpp
@@ -238,7 +238,7 @@ bool DamageManagerBase::canTakeDamage() {
     return item.mCanTakeDamageFromType[damageTypeMaybe] & 0x1;
 }
 
-void DamageManagerBase::handleDamageForPlayer(u32* a2, u32* a3, u32* a4, u32* a5, u32* a6) {
+void DamageManagerBase::handleDamageForPlayer(u32* a2, u32* a3, u32* a4, s32* a5, s32* a6) {
     Struct20* currentStruct = sead::DynamicCast<Struct20>(mStruct20_b);
     if (!currentStruct) {
         return;

--- a/src/Game/Damage/dmgDamageManagerBase.h
+++ b/src/Game/Damage/dmgDamageManagerBase.h
@@ -110,7 +110,7 @@ public:
     virtual void m43() {}
     virtual bool canTakeDamage();
     virtual void m45() {}
-    virtual void handleDamageForPlayer(u32* a2, u32* a3, u32* a4, u32* a5, u32* a6);
+    virtual void handleDamageForPlayer(u32* a2, u32* a3, u32* a4, s32* a5, s32* a6);
     virtual bool addDamage(s64 a2, s32 damage, s32 df48, s32 minDmg, s32 f50, s32 f54, s32 f40);
     virtual void onApplyDamage() {}
 
@@ -119,17 +119,21 @@ public:
 
     void clearCallbacks();
     void resetStuff();
-    void callDamageCallbacks(u32 a2, u32* a3, s32* a4, u32* a5, u32* a6, u32* a7, u64 a8);
+    void callDamageCallbacks(u32 a2, u32* a3, s32* a4, u32* a5, s32* a6, s32* a7, u64 a8);
     s64 calcMaybe();
 
     inline void tryBuffDamage(s32& damage);
     inline void tryApplyDamageRecovery(s32& damage);
 
-private:
+    void setDamageType(s32 type) { mDamageType = type; }
+
+    bool isOwnedByPlayer() const { return mIsOwnedByPlayer; }
+
+public:
     s32 mField_40 = 0;
-    s32 mDamage = 0;
+    u32 mDamage = 0;
     s32 mField_48 = 0;
-    s32 mMinDmg = 0;
+    u32 mMinDmg = 0;
     s32 mField_50 = -1;
     s32 mField_54 = -1;
     s32 mFlags2 = 0;

--- a/src/Game/Damage/dmgDamageMgrShield.cpp
+++ b/src/Game/Damage/dmgDamageMgrShield.cpp
@@ -1,0 +1,93 @@
+#include "Game/Damage/dmgDamageMgrShield.h"
+
+#include "Game/Actor/actWeapon.h"
+#include "KingSystem/ActorSystem/actActor.h"
+#include "KingSystem/ActorSystem/actActorConstDataAccess.h"
+
+namespace uking::dmg {
+
+DamageMgrShield::DamageMgrShield(ksys::act::Actor* actor) : DamageMgrWeapon(actor) {
+    mDamage2 = act::WeaponModifierInfo::getLifeMultiplier();
+    mIsDamageType4 = false;
+}
+
+DamageMgrShield::~DamageMgrShield() = default;
+
+void DamageMgrShield::setDamage2(f32 damage) {
+    mDamage2 = act::WeaponModifierInfo::getLifeMultiplier() * damage;
+}
+
+void DamageMgrShield::m22() {
+    u32 aDamage = 0;
+    u32 aDf48 = 0;
+    s32 a5 = -1;
+    s32 a6 = -1;
+    u32 aMinDmg = 0;
+
+    if (isOwnedByPlayer()) {
+        handleDamageForPlayer(&aDamage, &aDf48, &aMinDmg, &a5, &a6);
+    }
+
+    mIsDamageType4 = false;
+    resetStuff();
+
+    s32 bDamage = 0;
+    s32 bDf48 = 0;
+    s32 bMinDmg = 0;
+    s32 b6 = -1;
+    s32 b5 = -1;
+    s32 b7 = 0;
+
+    if (mField_34)
+        return;
+
+    if (isOwnedByPlayer() && shieldSurfDamageLogic(&bDamage, &bDf48, &bMinDmg, &b5, &b6, &b7) &&
+        addDamage(2, bDamage, bDf48, bMinDmg, b5, b6, b7)) {
+        setDamageType(2);
+    }
+
+    if (shieldDamageLogic(&bDamage, &bDf48, &bMinDmg, &b5, &b6, &b7) &&
+        addDamage(3, bDamage, bDf48, bMinDmg, b5, b6, b7)) {
+        setDamageType(3);
+    }
+
+    ksys::act::Chemical* chemical = mActor->getChemicalStuff();
+    if (chemical && chemical->value == 3) {
+        s32* life = mActor->getLife();
+        bDamage = life ? *life : 1;
+        bDf48 = 0;
+        bMinDmg = 0;
+        b5 = 9;
+        b6 = 30;
+        b7 = 1;
+        if (addDamage(1, bDamage, bDf48, bMinDmg, b5, b6, b7))
+            setDamageType(1);
+    }
+
+    if (addDamage(4, aDamage, aDf48, aMinDmg, a5, a6, 1)) {
+        mIsDamageType4 = true;
+        setDamageType(4);
+    }
+
+    callDamageCallbacks(0, &mDamage, &mField_48, &mMinDmg, &mField_50, &mField_54, 0);
+}
+
+s32 DamageMgrShield::getNumCallbacks() {
+    return 1;
+}
+
+void DamageMgrShield::preDelete1() {
+    m20();
+    resetStuff();
+    mCallback = nullptr;
+    mIsDamageType4 = false;
+}
+
+s32 DamageMgrShield::getDamage2() {
+    return mDamage2;
+}
+
+bool DamageMgrShield::isDamageType4() const {
+    return mIsDamageType4;
+}
+}  // namespace uking::dmg

--- a/src/Game/Damage/dmgDamageMgrShield.h
+++ b/src/Game/Damage/dmgDamageMgrShield.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include "Game/Damage/dmgDamageMgrWeapon.h"
+
+namespace ksys::act {
+// TODO: Move Chemical to correct file
+class Chemical {
+public:
+    char filler[0xc0];
+    u8 value;
+};
+}  // namespace ksys::act
+
+namespace uking::dmg {
+
+class DamageMgrShield : public DamageMgrWeapon {
+    SEAD_RTTI_OVERRIDE(DamageMgrShield, DamageMgrWeapon)
+
+public:
+    DamageMgrShield(ksys::act::Actor* actor);
+    ~DamageMgrShield() override;
+
+    void setDamage2(f32 damage) override;
+    void m22() override;
+    bool shieldSurfDamageLogic(s32* damage, s32* df48, s32* minDmg, s32* f50, s32* f54, s32* f40);
+    bool shieldDamageLogic(s32* damage, s32* df48, s32* minDmg, s32* f50, s32* f54, s32* f40);
+    s32 getNumCallbacks() override;
+
+    void preDelete1() override;
+    s32 getDamage2() override;
+    bool isDamageType4() const override;
+
+private:
+    /* 0x0068 */ void* mCallback = nullptr;
+    /* 0x0070 */ s32 mDamage2;
+    /* 0x0074 */ bool mIsDamageType4;
+};
+
+KSYS_CHECK_SIZE_NX150(DamageMgrShield, 0x78);
+
+}  // namespace uking::dmg

--- a/src/Game/Damage/dmgDamageMgrWeapon.h
+++ b/src/Game/Damage/dmgDamageMgrWeapon.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include "Game/Damage/dmgDamageManagerBase.h"
+
+namespace uking::dmg {
+
+class DamageMgrWeapon : public DamageManagerBase {
+    SEAD_RTTI_OVERRIDE(DamageMgrWeapon, DamageManagerBase)
+
+public:
+    DamageMgrWeapon(ksys::act::Actor* actor);
+
+    virtual void setDamage2(f32 damage);
+    virtual s32 getDamage2();
+    virtual s32 m52();
+    virtual bool isDamageType4() const;
+
+    void m20();
+};
+KSYS_CHECK_SIZE_NX150(DamageMgrWeapon, 0x68);
+
+}  // namespace uking::dmg


### PR DESCRIPTION
This is the first PR with an actual implementation. I have more questions than anything specially with names and file locations.  We have `DamageMgrBase` but also `DamageManagerBase` and they appear to be the same thing?  `ksys::res::Chemical` but this impl requires `ksys::act::Chemical`?

`hieldSurfDamageLogic` and `shieldDamageLogic` cast from Actor to something else. I couldn't figure out which actor this  is meant to be so for now I left those out.

Another thing to note is that the vtable is wrong, the order is not correct for rtti elements but this is probably an issue in `DamageManagerBase` and not in this class

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/187)
<!-- Reviewable:end -->
