### PR TITLE
Match phys::System contact listener flags and rigid body teardown

### DIFF
--- a/src/KingSystem/Physics/System/physContactListener.h
+++ b/src/KingSystem/Physics/System/physContactListener.h
@@ -42,6 +42,14 @@ public:
 
     void unregisterCollisionWithBody(RigidBody* body);
 
+    bool get90() const { return _90; }
+    void set90(bool value) { _90 = value; }
+    bool get91() const { return _91; }
+    void set91(bool value) { _91 = value; }
+    void setDisableContactPointInfoNotifications(bool value) {
+        mDisableContactPointInfoNotifications = value;
+    }
+
     void contactPointCallback(const hkpContactPointEvent& event) override;
     void collisionAddedCallback(const hkpCollisionEvent& event) override;
     void collisionRemovedCallback(const hkpCollisionEvent& event) override;

--- a/src/KingSystem/Physics/System/physContactListener.h
+++ b/src/KingSystem/Physics/System/physContactListener.h
@@ -42,8 +42,8 @@ public:
 
     void unregisterCollisionWithBody(RigidBody* body);
 
-    bool get90() const { return _90; }
-    void set90(bool value) { _90 = value; }
+    bool isMagneMassScalingEnabled() const { return mMagneMassScalingEnabled; }
+    void setMagneMassScalingEnabled(bool enabled) { mMagneMassScalingEnabled = enabled; }
     bool get91() const { return _91; }
     void set91(bool value) { _91 = value; }
     void setDisableContactPointInfoNotifications(bool value) {
@@ -133,7 +133,7 @@ protected:
     u32 mTrackedLayersBufferSize{};
     u32 mLayerCount{};
     sead::CriticalSection mCS;
-    bool _90 = false;
+    bool mMagneMassScalingEnabled = false;
     bool _91 = false;
     bool mDisableContactPointInfoNotifications = false;
 };

--- a/src/KingSystem/Physics/System/physEntityContactListener.cpp
+++ b/src/KingSystem/Physics/System/physEntityContactListener.cpp
@@ -275,7 +275,7 @@ static void updateMotionAccessorFlagsForMagneMassScaling(RigidBody* body_a, Rigi
 void EntityContactListener::setMagneMassScalingForContactIfNeeded(const hkpCollisionEvent& event,
                                                                   RigidBody* body_a,
                                                                   RigidBody* body_b) {
-    if (!System::instance()->getEntityContactListenerField90())
+    if (!System::instance()->isMagneMassScalingEnabled())
         return;
 
     if (!needsMagneMassScaling(event, body_a, body_b))
@@ -490,19 +490,19 @@ bool EntityContactListener::regularContactPointCallback(const hkpContactPointEve
         auto* modifier = hkpWorldConstraintUtil::findModifier(
             constraint, hkpConstraintAtom::TYPE_MODIFIER_VISCOUS_SURFACE);
 
-        const bool field90 = System::instance()->getEntityContactListenerField90();
+        const bool magne_mass_scaling_enabled = System::instance()->isMagneMassScalingEnabled();
 
         if (modifier && constraint->getUserData() & 1) {
             clearCallbackDelay(event);
 
-            if (field90 && hasEntityWithMotionFlag80(event)) {
+            if (magne_mass_scaling_enabled && hasEntityWithMotionFlag80(event)) {
                 updateMotionFlagsAtEndOfStep(event, body_a, body_b);
             } else {
                 body_a->getEntityMotionAccessor()->getContactFlags().makeAllZero();
                 body_b->getEntityMotionAccessor()->getContactFlags().makeAllZero();
                 removeViscousSurfaceModifier(event);
             }
-        } else if (field90 && needsMagneMassScaling(event, body_a, body_b) &&
+        } else if (magne_mass_scaling_enabled && needsMagneMassScaling(event, body_a, body_b) &&
                    !shouldProcessEntityContact(body_a, body_b)) {
             updateMotionAccessorFlagsForMagneMassScaling(body_a, body_b);
             setMagneMassScalingForContact(event, body_a, body_b);

--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -1,10 +1,12 @@
 #include "KingSystem/Physics/System/physSystem.h"
 #include <heap/seadHeap.h>
 #include <thread/seadThread.h>
+#include "KingSystem/ActorSystem/actBaseProcMgr.h"
 #include "KingSystem/Physics/Cloth/physClothResource.h"
 #include "KingSystem/Physics/Ragdoll/physRagdollControllerKeyList.h"
 #include "KingSystem/Physics/Ragdoll/physRagdollResource.h"
 #include "KingSystem/Physics/RigidBody/TeraMesh/physTeraMeshRigidBodyResource.h"
+#include "KingSystem/Physics/RigidBody/physRigidBody.h"
 #include "KingSystem/Physics/RigidBody/physRigidBodyResource.h"
 #include "KingSystem/Physics/StaticCompound/physStaticCompound.h"
 #include "KingSystem/Physics/SupportBone/physSupportBoneResource.h"
@@ -152,6 +154,49 @@ sead::Heap* System::getPhysicsTempHeap(LowPriority low_priority) const {
         mPhysicsTempDefaultHeap->dump();
 
     return mPhysicsTempDefaultHeap;
+}
+
+void System::removeRigidBodyFromContactSystem(RigidBody* body) {
+    const auto layer_type = getContactLayerType(body->getContactLayer());
+
+    if (mPaused)
+        mContactMgr->removeContactPointsWithBody(body);
+
+    mContactListeners[static_cast<s32>(layer_type)]->unregisterCollisionWithBody(body);
+    mContactMgr->removeCollisionEntriesWithBody(body);
+    mContactMgr->removeImpulseEntriesWithBody(body);
+}
+
+void System::setEntityContactListenerField90(bool value) {
+    mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->set90(value);
+}
+
+bool System::getEntityContactListenerField90() const {
+    return mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->get90();
+}
+
+void System::setEntityContactListenerField91(bool value) {
+    mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->set91(value);
+}
+
+bool System::getEntityContactListenerField91() const {
+    return mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->get91();
+}
+
+void System::setDisableSensorContactPointInfoNotifications(bool disable) {
+    mContactListeners[static_cast<s32>(ContactLayerType::Sensor)]
+        ->setDisableContactPointInfoNotifications(disable);
+}
+
+bool System::isActorSystemIdle() const {
+    const bool flag = _62 || _61;
+
+    auto* mgr = act::BaseProcMgr::instance();
+    if (!mgr)
+        return true;
+
+    const bool idle = mgr->getStatus() != act::BaseProcMgr::Status::ProcessingActorJobs;
+    return flag || idle;
 }
 
 }  // namespace ksys::phys

--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -167,12 +167,14 @@ void System::removeRigidBodyFromContactSystem(RigidBody* body) {
     mContactMgr->removeImpulseEntriesWithBody(body);
 }
 
-void System::setEntityContactListenerField90(bool value) {
-    mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->set90(value);
+void System::setMagneMassScalingEnabled(bool enabled) {
+    mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->setMagneMassScalingEnabled(
+        enabled);
 }
 
-bool System::getEntityContactListenerField90() const {
-    return mContactListeners[static_cast<s32>(ContactLayerType::Entity)]->get90();
+bool System::isMagneMassScalingEnabled() const {
+    return mContactListeners[static_cast<s32>(ContactLayerType::Entity)]
+        ->isMagneMassScalingEnabled();
 }
 
 void System::setEntityContactListenerField91(bool value) {
@@ -189,14 +191,14 @@ void System::setDisableSensorContactPointInfoNotifications(bool disable) {
 }
 
 bool System::isActorSystemIdle() const {
-    const bool flag = _62 || _61;
+    const bool is_idle = _62 || _61;
 
     auto* mgr = act::BaseProcMgr::instance();
     if (!mgr)
         return true;
 
-    const bool idle = mgr->getStatus() != act::BaseProcMgr::Status::ProcessingActorJobs;
-    return flag || idle;
+    const bool actor_jobs_idle = mgr->getStatus() != act::BaseProcMgr::Status::ProcessingActorJobs;
+    return is_idle || actor_jobs_idle;
 }
 
 }  // namespace ksys::phys

--- a/src/KingSystem/Physics/System/physSystem.h
+++ b/src/KingSystem/Physics/System/physSystem.h
@@ -129,6 +129,9 @@ public:
     // 0x0000007101216814
     bool getEntityContactListenerField91() const;
 
+    // 0x00000071012167ec
+    void setDisableSensorContactPointInfoNotifications(bool disable);
+
     // 0x000000710121682c
     void incrementWorldUnkCounter(ContactLayerType layer_type);
     // 0x000000710121684c
@@ -141,7 +144,9 @@ public:
 private:
     u8 _28[0x60 - 0x28];
     bool mPaused;
-    u8 _61[0x64 - 0x61];
+    u8 _61;
+    u8 _62;
+    u8 _63;
     float _64 = 1.0 / 30.0;
     float _68 = 1.0 / 30.0;
     float _6c = 1.0;

--- a/src/KingSystem/Physics/System/physSystem.h
+++ b/src/KingSystem/Physics/System/physSystem.h
@@ -115,11 +115,10 @@ public:
 
     RagdollControllerKeyList* getRagdollCtrlKeyList() const;
 
-    // TODO: rename
     // 0x0000007101216c60
-    void setEntityContactListenerField90(bool value);
+    void setMagneMassScalingEnabled(bool enabled);
     // 0x0000007101216c74
-    bool getEntityContactListenerField90() const;
+    bool isMagneMassScalingEnabled() const;
 
     // 0x0000007101216ca4
     bool isActorSystemIdle() const;
@@ -144,8 +143,8 @@ public:
 private:
     u8 _28[0x60 - 0x28];
     bool mPaused;
-    u8 _61;
-    u8 _62;
+    bool _61;
+    bool _62;
     u8 _63;
     float _64 = 1.0 / 30.0;
     float _68 = 1.0 / 30.0;


### PR DESCRIPTION
isActorSystemIdle reads two separate flags out of the _61 padding, so I split it into _61, _62 and _63 and left them u8; 0x7101216cb4 loads _61 with ldrb / cmp #0 / cset ne, and clang emits no cset for a bool. Writing the getStatus comparison into the return there short-circuits into an early ret and comes out four bytes short of the target's branchless orr, so I kept it in a local.

I named 0x71012167ec setDisableSensorContactPointInfoNotifications after the field it writes on the Sensor listener.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/188)
<!-- Reviewable:end -->
