### PR TITLE
Match phys::System static group handlers

### DIFF
--- a/src/KingSystem/Physics/System/physSystem.cpp
+++ b/src/KingSystem/Physics/System/physSystem.cpp
@@ -103,6 +103,26 @@ SystemGroupHandler* System::addSystemGroupHandler(ContactLayerType layer_type, i
     return getGroupFilter(layer_type)->addSystemGroupHandler(free_list_idx);
 }
 
+void System::initGroupHandlers() {
+    for (int i = 0; i < NumContactLayerTypes; ++i) {
+        const auto layer_type = static_cast<ContactLayerType>(i);
+        for (auto& handler : mStaticGroupHandlers[i])
+            handler = addSystemGroupHandler(layer_type, 0);
+        for (auto& handler : mStaticGroupHandlersLowIdx[i])
+            handler = addSystemGroupHandler(layer_type, 1);
+    }
+}
+
+SystemGroupHandler* System::getStaticGroupHandler(ContactLayerType layer_type,
+                                                  StaticGroupHandlerId id) const {
+    return mStaticGroupHandlers[static_cast<s32>(layer_type)][id];
+}
+
+SystemGroupHandler* System::getStaticGroupHandlerLowIdx(ContactLayerType layer_type,
+                                                        StaticGroupHandlerId id) const {
+    return mStaticGroupHandlersLowIdx[static_cast<s32>(layer_type)][id];
+}
+
 LayerContactPointInfo* System::allocLayerContactPointInfo(sead::Heap* heap, int num, int num2,
                                                           const sead::SafeString& name, int a,
                                                           int b, int c) const {

--- a/src/KingSystem/Physics/System/physSystem.h
+++ b/src/KingSystem/Physics/System/physSystem.h
@@ -2,6 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <container/seadPtrArray.h>
+#include <container/seadSafeArray.h>
 #include <heap/seadDisposer.h>
 #include <thread/seadCriticalSection.h>
 #include "KingSystem/Physics/physDefines.h"
@@ -38,6 +39,12 @@ enum class IsIndoorStage {
 
 enum class LowPriority : bool { Yes = true, No = false };
 enum class OnlyLockIfNeeded : bool { Yes = true, No = false };
+
+/// Selects one of the SystemGroupHandlers that System preallocates for each layer type.
+/// Enumerator names are unknown. This must stay a sead enum: operator int() is const volatile,
+/// so the index goes through the stack, and a plain int drops that spill and unmatches both
+/// getters.
+SEAD_ENUM(StaticGroupHandlerId, _0, _1, _2, _3)
 
 class System {
     SEAD_SINGLETON_DISPOSER(System)
@@ -96,6 +103,15 @@ public:
     SystemGroupHandler* addSystemGroupHandler(ContactLayerType layer_type, int free_list_idx = 0);
     // 0x0000007101215b68
     void removeSystemGroupHandler(SystemGroupHandler* handler);
+
+    // 0x0000007101215984
+    void initGroupHandlers();
+    // 0x0000007101216894
+    SystemGroupHandler* getStaticGroupHandler(ContactLayerType layer_type,
+                                              StaticGroupHandlerId id) const;
+    // 0x00000071012168c8
+    SystemGroupHandler* getStaticGroupHandlerLowIdx(ContactLayerType layer_type,
+                                                    StaticGroupHandlerId id) const;
 
     hkpWorld* getHavokWorld(ContactLayerType type) const;
 
@@ -172,7 +188,14 @@ private:
     sead::Heap* mDebugHeap{};
     sead::Heap* mPhysicsTempDefaultHeap{};
     sead::Heap* mPhysicsTempLowHeap{};
-    u8 _1c8[0x480 - 0x1c8];
+    u8 _1c8[0x2c0 - 0x1c8];
+    /// Handlers taken from group filter free list 0.
+    sead::SafeArray<sead::SafeArray<SystemGroupHandler*, 4>, NumContactLayerTypes>
+        mStaticGroupHandlers;
+    /// Handlers taken from group filter free list 1, which holds the handlers with a low index.
+    sead::SafeArray<sead::SafeArray<SystemGroupHandler*, 2>, NumContactLayerTypes>
+        mStaticGroupHandlersLowIdx;
+    u8 _320[0x480 - 0x320];
 };
 KSYS_CHECK_SIZE_NX150(System, 0x480);
 


### PR DESCRIPTION
I made the `StaticGroupHandlerId` parameter of both getters a `SEAD_ENUM` rather than an `int`, because the target spills that index to the stack and reloads it while indexing the outer dimension from `w1` directly. The round trip comes from `SEAD_ENUM`'s `operator int() const volatile`, and with an `int` both getters come out 40 bytes against the target's 52. The enumerator names are unknown, so they're written in the repo's `_N` placeholder style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/189)
<!-- Reviewable:end -->
