### PR TITLE
Match ksys game-over state accessors

### DIFF
--- a/src/KingSystem/ksys.cpp
+++ b/src/KingSystem/ksys.cpp
@@ -10,6 +10,18 @@
 
 namespace ksys {
 
+namespace {
+bool sIsGameOver;
+}
+
+bool isGameOver() {
+    return sIsGameOver;
+}
+
+void setIsGameOver(bool is_game_over) {
+    sIsGameOver = is_game_over;
+}
+
 void initBaseProcMgr(sead::Heap* heap) {
     sead::ScopedCurrentHeapSetter setter(heap);
 


### PR DESCRIPTION
I used one file-local `bool` because both functions reference the same BSS byte.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/193)
<!-- Reviewable:end -->
