### PR TITLE
Match IsOffLinkTag::doQuery

### DIFF
--- a/data/status_query.yml
+++ b/data/status_query.yml
@@ -283,7 +283,7 @@ query::IsNeedEquipWeapon:
 query::IsNoEquipArmorAnyTarget:
   status: pending
 query::IsOffLinkTag:
-  status: pending
+  status: done
 query::IsOnEnterDungeonFlag:
   status: done
 query::IsOnInstEventFlag:

--- a/src/Game/AI/Query/queryIsOffLinkTag.cpp
+++ b/src/Game/AI/Query/queryIsOffLinkTag.cpp
@@ -1,5 +1,6 @@
 #include "Game/AI/Query/queryIsOffLinkTag.h"
 #include <evfl/Query.h>
+#include "KingSystem/ActorSystem/actActor.h"
 
 namespace uking::query {
 
@@ -7,9 +8,8 @@ IsOffLinkTag::IsOffLinkTag(const InitArg& arg) : ksys::act::ai::Query(arg) {}
 
 IsOffLinkTag::~IsOffLinkTag() = default;
 
-// FIXME: implement
 int IsOffLinkTag::doQuery() {
-    return -1;
+    return !mActor->checkBasicSig();
 }
 
 void IsOffLinkTag::loadParams(const evfl::QueryArg& arg) {


### PR DESCRIPTION
Implements `IsOffLinkTag::doQuery` as the inverse of the actor's basic signal. I used only `mActor` because the target does not read `mSignalType`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/194)
<!-- Reviewable:end -->
