### PR TITLE
Match LifeRecoverInfo::onApplyDamage

### DIFF
--- a/src/Game/DLC/aocManager.cpp
+++ b/src/Game/DLC/aocManager.cpp
@@ -1,8 +1,11 @@
 #include "Game/DLC/aocManager.h"
+#include <algorithm>
 #include <container/seadBuffer.h>
 #include <filedevice/seadFileDeviceMgr.h>
+#include <math/seadMathCalcCommon.h>
 #include <prim/seadStringBuilder.h>
 #include <resource/seadSharcArchiveRes.h>
+#include "KingSystem/ActorSystem/actLifeRecoveryInfo.h"
 #include "KingSystem/Resource/resLoadRequest.h"
 #include "KingSystem/Resource/resResourceMgrTask.h"
 #include "KingSystem/Utils/InitTimeInfo.h"
@@ -14,6 +17,21 @@
 #include <nn/fs.h>
 #include <prim/seadStringUtil.h>
 #endif
+
+namespace ksys::act {
+
+bool LifeRecoverInfo::onApplyDamage(s32& damage) {
+    if (mExtraHp1 == 0)
+        return damage > 0;
+
+    const auto previous_extra_hp = mExtraHp1;
+    const auto remaining_extra_hp = std::max(previous_extra_hp - damage, 0);
+    damage -= previous_extra_hp - remaining_extra_hp;
+    mExtraHp1 = sead::Mathf::clampMax(remaining_extra_hp, mExtraHp2);
+    return remaining_extra_hp != previous_extra_hp;
+}
+
+}  // namespace ksys::act
 
 namespace uking::aoc {
 

--- a/src/KingSystem/ActorSystem/actLifeRecoveryInfo.h
+++ b/src/KingSystem/ActorSystem/actLifeRecoveryInfo.h
@@ -23,8 +23,8 @@ public:
     f32 mCounter;
     f32 mField_4;
     u8 gap_8[16];  // Is this really a gap?
-    u32 mExtraHp1;
-    u32 mExtraHp2;
+    s32 mExtraHp1;
+    s32 mExtraHp2;
     u32 mMaxLife;
     f32 mRecoverFactor;
     s32 mField_28;


### PR DESCRIPTION
`LifeRecoverInfo::onApplyDamage` absorbs damage through its recoverable HP pool. I typed both pool fields as `s32`; the target uses signed integer-to-float conversions before `sead::Mathf::clampMax`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeldaret/botw/195)
<!-- Reviewable:end -->
